### PR TITLE
add nlb target type option

### DIFF
--- a/provider/pkg/provider/cluster.go
+++ b/provider/pkg/provider/cluster.go
@@ -31,6 +31,7 @@ type IngressConfig struct {
 	ServiceMonitorNamespace pulumi.StringInput `pulumi:"serviceMonitorNamespace"`
 	ControllerReplicas      pulumi.IntInput    `pulumi:"controllerReplicas"`
 	AdditionalConfig        pulumi.MapInput    `pulumi:"additionalConfig"`
+	NlbTargetType           pulumi.StringInput `pulumi:"nlbTargetType"`
 }
 
 // The set of arguments for creating a Cluster component resource.
@@ -583,12 +584,14 @@ func NewCluster(ctx *pulumi.Context,
 			"service.beta.kubernetes.io/aws-load-balancer-ssl-ports":        pulumi.String("https"),
 			"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": pulumi.String("tcp"),
 			"service.beta.kubernetes.io/aws-load-balancer-type":             args.LbType,
+			"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":  args.IngressConfig.NlbTargetType,
 		}
 	} else {
 		externalAnnotations = pulumi.Map{
 			"service.beta.kubernetes.io/aws-load-balancer-ssl-ports":        pulumi.String("https"),
 			"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": pulumi.String("tcp"),
 			"service.beta.kubernetes.io/aws-load-balancer-type":             args.LbType,
+			"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":  args.IngressConfig.NlbTargetType,
 		}
 	}
 
@@ -683,6 +686,7 @@ func NewCluster(ctx *pulumi.Context,
 				"service.beta.kubernetes.io/aws-load-balancer-internal":         pulumi.Bool(true),
 				"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": pulumi.String("tcp"),
 				"service.beta.kubernetes.io/aws-load-balancer-type":             args.LbType,
+				"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":  args.IngressConfig.NlbTargetType,
 			}
 		} else {
 			internalAnnotations = pulumi.Map{
@@ -690,6 +694,7 @@ func NewCluster(ctx *pulumi.Context,
 				"service.beta.kubernetes.io/aws-load-balancer-internal":         pulumi.Bool(true),
 				"service.beta.kubernetes.io/aws-load-balancer-backend-protocol": pulumi.String("tcp"),
 				"service.beta.kubernetes.io/aws-load-balancer-type":             args.LbType,
+				"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":  args.IngressConfig.NlbTargetType,
 			}
 		}
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -34,6 +34,12 @@ types:
         type: number
         default: 1
         description: The number of replicas of the ingress controller.
+      nlbTargetType:
+        type: string
+        additionalProperties:
+          type: string
+        description: NLB target type for NLB loadbalancers.
+        default: "ip"
       additionalConfig:
         type: object
         additionalProperties:

--- a/sdk/dotnet/Eks/Inputs/IngressConfigArgs.cs
+++ b/sdk/dotnet/Eks/Inputs/IngressConfigArgs.cs
@@ -47,6 +47,12 @@ namespace Lbrlabs.PulumiPackage.Eks.Inputs
         public Input<bool>? EnableServiceMonitor { get; set; }
 
         /// <summary>
+        /// NLB target type for NLB loadbalancers.
+        /// </summary>
+        [Input("nlbTargetType")]
+        public Input<string>? NlbTargetType { get; set; }
+
+        /// <summary>
         /// The namespace to deploy the service monitor to.
         /// </summary>
         [Input("serviceMonitorNamespace")]
@@ -57,6 +63,7 @@ namespace Lbrlabs.PulumiPackage.Eks.Inputs
             ControllerReplicas = 1;
             EnableMetrics = false;
             EnableServiceMonitor = false;
+            NlbTargetType = "ip";
         }
         public static new IngressConfigArgs Empty => new IngressConfigArgs();
     }

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -24,6 +24,8 @@ type IngressConfig struct {
 	EnableMetrics *bool `pulumi:"enableMetrics"`
 	// Enable the service monitor for kube-prometheus-stackl.
 	EnableServiceMonitor *bool `pulumi:"enableServiceMonitor"`
+	// NLB target type for NLB loadbalancers.
+	NlbTargetType *string `pulumi:"nlbTargetType"`
 	// The namespace to deploy the service monitor to.
 	ServiceMonitorNamespace *string `pulumi:"serviceMonitorNamespace"`
 }
@@ -45,6 +47,10 @@ func (val *IngressConfig) Defaults() *IngressConfig {
 	if tmp.EnableServiceMonitor == nil {
 		enableServiceMonitor_ := false
 		tmp.EnableServiceMonitor = &enableServiceMonitor_
+	}
+	if tmp.NlbTargetType == nil {
+		nlbTargetType_ := "ip"
+		tmp.NlbTargetType = &nlbTargetType_
 	}
 	return &tmp
 }
@@ -70,6 +76,8 @@ type IngressConfigArgs struct {
 	EnableMetrics pulumi.BoolPtrInput `pulumi:"enableMetrics"`
 	// Enable the service monitor for kube-prometheus-stackl.
 	EnableServiceMonitor pulumi.BoolPtrInput `pulumi:"enableServiceMonitor"`
+	// NLB target type for NLB loadbalancers.
+	NlbTargetType pulumi.StringPtrInput `pulumi:"nlbTargetType"`
 	// The namespace to deploy the service monitor to.
 	ServiceMonitorNamespace pulumi.StringPtrInput `pulumi:"serviceMonitorNamespace"`
 }
@@ -88,6 +96,9 @@ func (val *IngressConfigArgs) Defaults() *IngressConfigArgs {
 	}
 	if tmp.EnableServiceMonitor == nil {
 		tmp.EnableServiceMonitor = pulumi.BoolPtr(false)
+	}
+	if tmp.NlbTargetType == nil {
+		tmp.NlbTargetType = pulumi.StringPtr("ip")
 	}
 	return &tmp
 }
@@ -207,6 +218,11 @@ func (o IngressConfigOutput) EnableServiceMonitor() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v IngressConfig) *bool { return v.EnableServiceMonitor }).(pulumi.BoolPtrOutput)
 }
 
+// NLB target type for NLB loadbalancers.
+func (o IngressConfigOutput) NlbTargetType() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v IngressConfig) *string { return v.NlbTargetType }).(pulumi.StringPtrOutput)
+}
+
 // The namespace to deploy the service monitor to.
 func (o IngressConfigOutput) ServiceMonitorNamespace() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v IngressConfig) *string { return v.ServiceMonitorNamespace }).(pulumi.StringPtrOutput)
@@ -280,6 +296,16 @@ func (o IngressConfigPtrOutput) EnableServiceMonitor() pulumi.BoolPtrOutput {
 		}
 		return v.EnableServiceMonitor
 	}).(pulumi.BoolPtrOutput)
+}
+
+// NLB target type for NLB loadbalancers.
+func (o IngressConfigPtrOutput) NlbTargetType() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *IngressConfig) *string {
+		if v == nil {
+			return nil
+		}
+		return v.NlbTargetType
+	}).(pulumi.StringPtrOutput)
 }
 
 // The namespace to deploy the service monitor to.

--- a/sdk/go/eks/x/pulumiTypes.go
+++ b/sdk/go/eks/x/pulumiTypes.go
@@ -24,6 +24,8 @@ type IngressConfig struct {
 	EnableMetrics *bool `pulumi:"enableMetrics"`
 	// Enable the service monitor for kube-prometheus-stackl.
 	EnableServiceMonitor *bool `pulumi:"enableServiceMonitor"`
+	// NLB target type for NLB loadbalancers.
+	NlbTargetType *string `pulumi:"nlbTargetType"`
 	// The namespace to deploy the service monitor to.
 	ServiceMonitorNamespace *string `pulumi:"serviceMonitorNamespace"`
 }
@@ -46,6 +48,10 @@ func (val *IngressConfig) Defaults() *IngressConfig {
 		enableServiceMonitor_ := false
 		tmp.EnableServiceMonitor = &enableServiceMonitor_
 	}
+	if tmp.NlbTargetType == nil {
+		nlbTargetType_ := "ip"
+		tmp.NlbTargetType = &nlbTargetType_
+	}
 	return &tmp
 }
 
@@ -59,6 +65,8 @@ type IngressConfigArgs struct {
 	EnableMetrics pulumix.Input[*bool] `pulumi:"enableMetrics"`
 	// Enable the service monitor for kube-prometheus-stackl.
 	EnableServiceMonitor pulumix.Input[*bool] `pulumi:"enableServiceMonitor"`
+	// NLB target type for NLB loadbalancers.
+	NlbTargetType pulumix.Input[*string] `pulumi:"nlbTargetType"`
 	// The namespace to deploy the service monitor to.
 	ServiceMonitorNamespace pulumix.Input[*string] `pulumi:"serviceMonitorNamespace"`
 }
@@ -77,6 +85,9 @@ func (val *IngressConfigArgs) Defaults() *IngressConfigArgs {
 	}
 	if tmp.EnableServiceMonitor == nil {
 		tmp.EnableServiceMonitor = pulumix.Ptr(false)
+	}
+	if tmp.NlbTargetType == nil {
+		tmp.NlbTargetType = pulumix.Ptr("ip")
 	}
 	return &tmp
 }
@@ -136,6 +147,11 @@ func (o IngressConfigOutput) EnableMetrics() pulumix.Output[*bool] {
 // Enable the service monitor for kube-prometheus-stackl.
 func (o IngressConfigOutput) EnableServiceMonitor() pulumix.Output[*bool] {
 	return pulumix.Apply[IngressConfig](o, func(v IngressConfig) *bool { return v.EnableServiceMonitor })
+}
+
+// NLB target type for NLB loadbalancers.
+func (o IngressConfigOutput) NlbTargetType() pulumix.Output[*string] {
+	return pulumix.Apply[IngressConfig](o, func(v IngressConfig) *string { return v.NlbTargetType })
 }
 
 // The namespace to deploy the service monitor to.

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -28,6 +28,10 @@ export interface IngressConfigArgs {
      */
     enableServiceMonitor?: pulumi.Input<boolean>;
     /**
+     * NLB target type for NLB loadbalancers.
+     */
+    nlbTargetType?: pulumi.Input<string>;
+    /**
      * The namespace to deploy the service monitor to.
      */
     serviceMonitorNamespace?: pulumi.Input<string>;
@@ -41,6 +45,7 @@ export function ingressConfigArgsProvideDefaults(val: IngressConfigArgs): Ingres
         controllerReplicas: (val.controllerReplicas) ?? 1,
         enableMetrics: (val.enableMetrics) ?? false,
         enableServiceMonitor: (val.enableServiceMonitor) ?? false,
+        nlbTargetType: (val.nlbTargetType) ?? "ip",
     };
 }
 

--- a/sdk/python/lbrlabs_pulumi_eks/_inputs.py
+++ b/sdk/python/lbrlabs_pulumi_eks/_inputs.py
@@ -21,6 +21,7 @@ class IngressConfigArgs:
                  controller_replicas: Optional[pulumi.Input[float]] = None,
                  enable_metrics: Optional[pulumi.Input[bool]] = None,
                  enable_service_monitor: Optional[pulumi.Input[bool]] = None,
+                 nlb_target_type: Optional[pulumi.Input[str]] = None,
                  service_monitor_namespace: Optional[pulumi.Input[str]] = None):
         """
         Configuration for the ingress controller.
@@ -28,6 +29,7 @@ class IngressConfigArgs:
         :param pulumi.Input[float] controller_replicas: The number of replicas of the ingress controller.
         :param pulumi.Input[bool] enable_metrics: Enable metrics for the ingress controller.
         :param pulumi.Input[bool] enable_service_monitor: Enable the service monitor for kube-prometheus-stackl.
+        :param pulumi.Input[str] nlb_target_type: NLB target type for NLB loadbalancers.
         :param pulumi.Input[str] service_monitor_namespace: The namespace to deploy the service monitor to.
         """
         if additional_config is not None:
@@ -44,6 +46,10 @@ class IngressConfigArgs:
             enable_service_monitor = False
         if enable_service_monitor is not None:
             pulumi.set(__self__, "enable_service_monitor", enable_service_monitor)
+        if nlb_target_type is None:
+            nlb_target_type = 'ip'
+        if nlb_target_type is not None:
+            pulumi.set(__self__, "nlb_target_type", nlb_target_type)
         if service_monitor_namespace is not None:
             pulumi.set(__self__, "service_monitor_namespace", service_monitor_namespace)
 
@@ -94,6 +100,18 @@ class IngressConfigArgs:
     @enable_service_monitor.setter
     def enable_service_monitor(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "enable_service_monitor", value)
+
+    @property
+    @pulumi.getter(name="nlbTargetType")
+    def nlb_target_type(self) -> Optional[pulumi.Input[str]]:
+        """
+        NLB target type for NLB loadbalancers.
+        """
+        return pulumi.get(self, "nlb_target_type")
+
+    @nlb_target_type.setter
+    def nlb_target_type(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "nlb_target_type", value)
 
     @property
     @pulumi.getter(name="serviceMonitorNamespace")


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 822cdbe161ed3e05c0f0cc90263733b1580402c8.  | 
|--------|--------|

### Summary:
This PR introduces a new `NlbTargetType` option for the Network Load Balancer in the IngressConfig structure across multiple files and SDKs, with a default value of 'ip'.

**Key points**:
- Added `NlbTargetType` option in `IngressConfig` structure across multiple files.
- Default value for `NlbTargetType` is set to 'ip'.
- Changes reflected in `schema.yaml`, `cluster.go`, and SDKs for Go, Python, Node.js, and .NET.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
