### PR TITLE
feat(autoscaling): integrate budget configurations, update Karpenter, and expand SDK support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         language:
         - nodejs
         - python
@@ -153,7 +153,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -196,7 +196,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -271,7 +271,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -348,7 +348,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         language:
         - nodejs
         - python

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -84,7 +84,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         language:
         - nodejs
         - python
@@ -154,7 +154,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -197,7 +197,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -272,7 +272,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -349,7 +349,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         language:
         - nodejs
         - python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         language:
         - nodejs
         - python
@@ -153,7 +153,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -196,7 +196,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -271,7 +271,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         nodeversion:
         - 20.x
         pythonversion:
@@ -348,7 +348,7 @@ jobs:
         dotnetversion:
         - 3.1.301
         goversion:
-        - 1.21.x
+        - 1.22.x
         language:
         - nodejs
         - python

--- a/provider/pkg/provider/autoscaledNodegroup.go
+++ b/provider/pkg/provider/autoscaledNodegroup.go
@@ -17,7 +17,7 @@ type DisruptionConfig struct {
 	ConsolidationPolicy pulumi.StringInput `pulumi:"consolidationPolicy"`
 	ConsolidateAfter    pulumi.StringInput `pulumi:"consolidateAfter"`
 	ExpireAfter         pulumi.StringInput `pulumi:"expireAfter"`
-	//Budgets             []BudgetConfig     `pulumi:"budgets"`
+	Budgets             []BudgetConfig     `pulumi:"budgets"`
 }
 
 type AutoscaledNodeGroupArgs struct {
@@ -143,14 +143,14 @@ func NewAutoscaledNodeGroup(ctx *pulumi.Context,
 		return nil, fmt.Errorf("error creating autoscaled node class: %w", err)
 	}
 
-	// var budgetsInput []interface{}
-	// for _, budget := range disruption.Budgets {
-	// 	budgetsInput = append(budgetsInput, map[string]interface{}{
-	// 		"nodes":    budget.Nodes,
-	// 		"schedule": budget.Schedule,
-	// 		"duration": budget.Duration,
-	// 	})
-	// }
+	var budgetsInput []interface{}
+	for _, budget := range disruption.Budgets {
+		budgetsInput = append(budgetsInput, map[string]interface{}{
+			"nodes":    budget.Nodes,
+			"schedule": budget.Schedule,
+			"duration": budget.Duration,
+		})
+	}
 
 	_, err = apiextensions.NewCustomResource(ctx, fmt.Sprintf("%s-nodepool", name), &apiextensions.CustomResourceArgs{
 		ApiVersion: pulumi.String("karpenter.sh/v1beta1"),
@@ -164,7 +164,7 @@ func NewAutoscaledNodeGroup(ctx *pulumi.Context,
 					"consolidationPolicy": disruption.ConsolidationPolicy,
 					"consolidateAfter":    disruption.ConsolidateAfter,
 					"expireAfter":         disruption.ExpireAfter,
-					//"budgets":             budgetsInput,
+					"budgets":             budgetsInput,
 				},
 				"template": map[string]interface{}{
 					"metadata": map[string]interface{}{

--- a/schema.yaml
+++ b/schema.yaml
@@ -15,19 +15,19 @@ keywords:
   - category/cloud
 repository: "https://github.com/lbrlabs/pulumi-lbrlabs-eks"
 types:
-  # lbrlabs-eks:index:BudgetConfig:
-  #   description: Configuration for Autoscaled Node budgets.
-  #   type: object
-  #   properties:
-  #     nodes:
-  #       type: string
-  #       description: The maximum number of nodes that can be scaled down at any time.
-  #     schedule:
-  #       type: string
-  #       description: A cron schedule for when disruption can happen.
-  #     duration:
-  #       type: string
-  #       description: The duration during which disruptuon can happen.
+  lbrlabs-eks:index:BudgetConfig:
+    description: Configuration for Autoscaled Node budgets.
+    type: object
+    properties:
+      nodes:
+        type: string
+        description: The maximum number of nodes that can be scaled down at any time.
+      schedule:
+        type: string
+        description: A cron schedule for when disruption can happen.
+      duration:
+        type: string
+        description: The duration during which disruptuon can happen.
   lbrlabs-eks:index:DisruptionConfig:
     description: Configuration for Autoscaled nodes disruption.
     type: object
@@ -41,21 +41,19 @@ types:
         - Name: "Underutilized"
           Description: "Consolidate Nodes when they are underutilized."
           Value: "WhenUnderutilized"
-        default: "WhenUnderutilized"
+        default: "WhenEmpty"
         description: Describes which types of Nodes Karpenter should consider for consolidation.
       consolidateAfter:
         type: string
-        default: "30s"
         description: The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
       expireAfter:
         type: string
-        default: "720h"
         description: The amount of time a Node can live on the cluster before being removed.
-      # budgets:
-      #   type: array
-      #   items:
-      #     "$ref": "#/types/lbrlabs-eks:index:BudgetConfig"
-      #   description: "Budgets control the speed Karpenter can scale down nodes."
+      budgets:
+        type: array
+        items:
+          "$ref": "#/types/lbrlabs-eks:index:BudgetConfig"
+        description: "Budgets control the speed Karpenter can scale down nodes."
   lbrlabs-eks:index:IngressConfig:
     description: Configuration for the ingress controller.
     type: object

--- a/sdk/dotnet/Eks/Inputs/DisruptionConfigArgs.cs
+++ b/sdk/dotnet/Eks/Inputs/DisruptionConfigArgs.cs
@@ -48,8 +48,7 @@ namespace Lbrlabs.PulumiPackage.Eks.Inputs
 
         public DisruptionConfigArgs()
         {
-            ConsolidationPolicy = "WhenUnderutilized";
-            ExpireAfter = "720h";
+            ConsolidationPolicy = "WhenEmpty";
         }
         public static new DisruptionConfigArgs Empty => new DisruptionConfigArgs();
     }

--- a/sdk/dotnet/Eks/Inputs/DisruptionConfigArgs.cs
+++ b/sdk/dotnet/Eks/Inputs/DisruptionConfigArgs.cs
@@ -16,6 +16,18 @@ namespace Lbrlabs.PulumiPackage.Eks.Inputs
     /// </summary>
     public sealed class DisruptionConfigArgs : global::Pulumi.ResourceArgs
     {
+        [Input("budgets")]
+        private InputList<Inputs.BudgetConfigArgs>? _budgets;
+
+        /// <summary>
+        /// Budgets control the speed Karpenter can scale down nodes.
+        /// </summary>
+        public InputList<Inputs.BudgetConfigArgs> Budgets
+        {
+            get => _budgets ?? (_budgets = new InputList<Inputs.BudgetConfigArgs>());
+            set => _budgets = value;
+        }
+
         /// <summary>
         /// The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
         /// </summary>
@@ -36,7 +48,6 @@ namespace Lbrlabs.PulumiPackage.Eks.Inputs
 
         public DisruptionConfigArgs()
         {
-            ConsolidateAfter = "30s";
             ConsolidationPolicy = "WhenUnderutilized";
             ExpireAfter = "720h";
         }

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -175,12 +175,8 @@ func (val *DisruptionConfig) Defaults() *DisruptionConfig {
 	}
 	tmp := *val
 	if tmp.ConsolidationPolicy == nil {
-		consolidationPolicy_ := "WhenUnderutilized"
+		consolidationPolicy_ := "WhenEmpty"
 		tmp.ConsolidationPolicy = &consolidationPolicy_
-	}
-	if tmp.ExpireAfter == nil {
-		expireAfter_ := "720h"
-		tmp.ExpireAfter = &expireAfter_
 	}
 	return &tmp
 }
@@ -215,10 +211,7 @@ func (val *DisruptionConfigArgs) Defaults() *DisruptionConfigArgs {
 	}
 	tmp := *val
 	if tmp.ConsolidationPolicy == nil {
-		tmp.ConsolidationPolicy = pulumi.StringPtr("WhenUnderutilized")
-	}
-	if tmp.ExpireAfter == nil {
-		tmp.ExpireAfter = pulumi.StringPtr("720h")
+		tmp.ConsolidationPolicy = pulumi.StringPtr("WhenEmpty")
 	}
 	return &tmp
 }

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -14,8 +14,152 @@ import (
 
 var _ = internal.GetEnvOrDefault
 
+// Configuration for Autoscaled Node budgets.
+type BudgetConfig struct {
+	// The duration during which disruptuon can happen.
+	Duration *string `pulumi:"duration"`
+	// The maximum number of nodes that can be scaled down at any time.
+	Nodes *string `pulumi:"nodes"`
+	// A cron schedule for when disruption can happen.
+	Schedule *string `pulumi:"schedule"`
+}
+
+// BudgetConfigInput is an input type that accepts BudgetConfigArgs and BudgetConfigOutput values.
+// You can construct a concrete instance of `BudgetConfigInput` via:
+//
+//	BudgetConfigArgs{...}
+type BudgetConfigInput interface {
+	pulumi.Input
+
+	ToBudgetConfigOutput() BudgetConfigOutput
+	ToBudgetConfigOutputWithContext(context.Context) BudgetConfigOutput
+}
+
+// Configuration for Autoscaled Node budgets.
+type BudgetConfigArgs struct {
+	// The duration during which disruptuon can happen.
+	Duration pulumi.StringPtrInput `pulumi:"duration"`
+	// The maximum number of nodes that can be scaled down at any time.
+	Nodes pulumi.StringPtrInput `pulumi:"nodes"`
+	// A cron schedule for when disruption can happen.
+	Schedule pulumi.StringPtrInput `pulumi:"schedule"`
+}
+
+func (BudgetConfigArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*BudgetConfig)(nil)).Elem()
+}
+
+func (i BudgetConfigArgs) ToBudgetConfigOutput() BudgetConfigOutput {
+	return i.ToBudgetConfigOutputWithContext(context.Background())
+}
+
+func (i BudgetConfigArgs) ToBudgetConfigOutputWithContext(ctx context.Context) BudgetConfigOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(BudgetConfigOutput)
+}
+
+func (i BudgetConfigArgs) ToOutput(ctx context.Context) pulumix.Output[BudgetConfig] {
+	return pulumix.Output[BudgetConfig]{
+		OutputState: i.ToBudgetConfigOutputWithContext(ctx).OutputState,
+	}
+}
+
+// BudgetConfigArrayInput is an input type that accepts BudgetConfigArray and BudgetConfigArrayOutput values.
+// You can construct a concrete instance of `BudgetConfigArrayInput` via:
+//
+//	BudgetConfigArray{ BudgetConfigArgs{...} }
+type BudgetConfigArrayInput interface {
+	pulumi.Input
+
+	ToBudgetConfigArrayOutput() BudgetConfigArrayOutput
+	ToBudgetConfigArrayOutputWithContext(context.Context) BudgetConfigArrayOutput
+}
+
+type BudgetConfigArray []BudgetConfigInput
+
+func (BudgetConfigArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]BudgetConfig)(nil)).Elem()
+}
+
+func (i BudgetConfigArray) ToBudgetConfigArrayOutput() BudgetConfigArrayOutput {
+	return i.ToBudgetConfigArrayOutputWithContext(context.Background())
+}
+
+func (i BudgetConfigArray) ToBudgetConfigArrayOutputWithContext(ctx context.Context) BudgetConfigArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(BudgetConfigArrayOutput)
+}
+
+func (i BudgetConfigArray) ToOutput(ctx context.Context) pulumix.Output[[]BudgetConfig] {
+	return pulumix.Output[[]BudgetConfig]{
+		OutputState: i.ToBudgetConfigArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
+// Configuration for Autoscaled Node budgets.
+type BudgetConfigOutput struct{ *pulumi.OutputState }
+
+func (BudgetConfigOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*BudgetConfig)(nil)).Elem()
+}
+
+func (o BudgetConfigOutput) ToBudgetConfigOutput() BudgetConfigOutput {
+	return o
+}
+
+func (o BudgetConfigOutput) ToBudgetConfigOutputWithContext(ctx context.Context) BudgetConfigOutput {
+	return o
+}
+
+func (o BudgetConfigOutput) ToOutput(ctx context.Context) pulumix.Output[BudgetConfig] {
+	return pulumix.Output[BudgetConfig]{
+		OutputState: o.OutputState,
+	}
+}
+
+// The duration during which disruptuon can happen.
+func (o BudgetConfigOutput) Duration() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v BudgetConfig) *string { return v.Duration }).(pulumi.StringPtrOutput)
+}
+
+// The maximum number of nodes that can be scaled down at any time.
+func (o BudgetConfigOutput) Nodes() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v BudgetConfig) *string { return v.Nodes }).(pulumi.StringPtrOutput)
+}
+
+// A cron schedule for when disruption can happen.
+func (o BudgetConfigOutput) Schedule() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v BudgetConfig) *string { return v.Schedule }).(pulumi.StringPtrOutput)
+}
+
+type BudgetConfigArrayOutput struct{ *pulumi.OutputState }
+
+func (BudgetConfigArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]BudgetConfig)(nil)).Elem()
+}
+
+func (o BudgetConfigArrayOutput) ToBudgetConfigArrayOutput() BudgetConfigArrayOutput {
+	return o
+}
+
+func (o BudgetConfigArrayOutput) ToBudgetConfigArrayOutputWithContext(ctx context.Context) BudgetConfigArrayOutput {
+	return o
+}
+
+func (o BudgetConfigArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]BudgetConfig] {
+	return pulumix.Output[[]BudgetConfig]{
+		OutputState: o.OutputState,
+	}
+}
+
+func (o BudgetConfigArrayOutput) Index(i pulumi.IntInput) BudgetConfigOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) BudgetConfig {
+		return vs[0].([]BudgetConfig)[vs[1].(int)]
+	}).(BudgetConfigOutput)
+}
+
 // Configuration for Autoscaled nodes disruption.
 type DisruptionConfig struct {
+	// Budgets control the speed Karpenter can scale down nodes.
+	Budgets []BudgetConfig `pulumi:"budgets"`
 	// The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
 	ConsolidateAfter *string `pulumi:"consolidateAfter"`
 	// Describes which types of Nodes Karpenter should consider for consolidation.
@@ -30,10 +174,6 @@ func (val *DisruptionConfig) Defaults() *DisruptionConfig {
 		return nil
 	}
 	tmp := *val
-	if tmp.ConsolidateAfter == nil {
-		consolidateAfter_ := "30s"
-		tmp.ConsolidateAfter = &consolidateAfter_
-	}
 	if tmp.ConsolidationPolicy == nil {
 		consolidationPolicy_ := "WhenUnderutilized"
 		tmp.ConsolidationPolicy = &consolidationPolicy_
@@ -58,6 +198,8 @@ type DisruptionConfigInput interface {
 
 // Configuration for Autoscaled nodes disruption.
 type DisruptionConfigArgs struct {
+	// Budgets control the speed Karpenter can scale down nodes.
+	Budgets BudgetConfigArrayInput `pulumi:"budgets"`
 	// The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
 	ConsolidateAfter pulumi.StringPtrInput `pulumi:"consolidateAfter"`
 	// Describes which types of Nodes Karpenter should consider for consolidation.
@@ -72,9 +214,6 @@ func (val *DisruptionConfigArgs) Defaults() *DisruptionConfigArgs {
 		return nil
 	}
 	tmp := *val
-	if tmp.ConsolidateAfter == nil {
-		tmp.ConsolidateAfter = pulumi.StringPtr("30s")
-	}
 	if tmp.ConsolidationPolicy == nil {
 		tmp.ConsolidationPolicy = pulumi.StringPtr("WhenUnderutilized")
 	}
@@ -179,6 +318,11 @@ func (o DisruptionConfigOutput) ToOutput(ctx context.Context) pulumix.Output[Dis
 	}
 }
 
+// Budgets control the speed Karpenter can scale down nodes.
+func (o DisruptionConfigOutput) Budgets() BudgetConfigArrayOutput {
+	return o.ApplyT(func(v DisruptionConfig) []BudgetConfig { return v.Budgets }).(BudgetConfigArrayOutput)
+}
+
 // The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
 func (o DisruptionConfigOutput) ConsolidateAfter() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v DisruptionConfig) *string { return v.ConsolidateAfter }).(pulumi.StringPtrOutput)
@@ -222,6 +366,16 @@ func (o DisruptionConfigPtrOutput) Elem() DisruptionConfigOutput {
 		var ret DisruptionConfig
 		return ret
 	}).(DisruptionConfigOutput)
+}
+
+// Budgets control the speed Karpenter can scale down nodes.
+func (o DisruptionConfigPtrOutput) Budgets() BudgetConfigArrayOutput {
+	return o.ApplyT(func(v *DisruptionConfig) []BudgetConfig {
+		if v == nil {
+			return nil
+		}
+		return v.Budgets
+	}).(BudgetConfigArrayOutput)
 }
 
 // The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
@@ -711,12 +865,16 @@ type Taint struct {
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*BudgetConfigInput)(nil)).Elem(), BudgetConfigArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*BudgetConfigArrayInput)(nil)).Elem(), BudgetConfigArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*DisruptionConfigInput)(nil)).Elem(), DisruptionConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*DisruptionConfigPtrInput)(nil)).Elem(), DisruptionConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*IngressConfigInput)(nil)).Elem(), IngressConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*IngressConfigPtrInput)(nil)).Elem(), IngressConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*RequirementInput)(nil)).Elem(), RequirementArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*RequirementArrayInput)(nil)).Elem(), RequirementArray{})
+	pulumi.RegisterOutputType(BudgetConfigOutput{})
+	pulumi.RegisterOutputType(BudgetConfigArrayOutput{})
 	pulumi.RegisterOutputType(DisruptionConfigOutput{})
 	pulumi.RegisterOutputType(DisruptionConfigPtrOutput{})
 	pulumi.RegisterOutputType(IngressConfigOutput{})

--- a/sdk/go/eks/x/pulumiTypes.go
+++ b/sdk/go/eks/x/pulumiTypes.go
@@ -14,8 +14,82 @@ import (
 
 var _ = internal.GetEnvOrDefault
 
+// Configuration for Autoscaled Node budgets.
+type BudgetConfig struct {
+	// The duration during which disruptuon can happen.
+	Duration *string `pulumi:"duration"`
+	// The maximum number of nodes that can be scaled down at any time.
+	Nodes *string `pulumi:"nodes"`
+	// A cron schedule for when disruption can happen.
+	Schedule *string `pulumi:"schedule"`
+}
+
+// Configuration for Autoscaled Node budgets.
+type BudgetConfigArgs struct {
+	// The duration during which disruptuon can happen.
+	Duration pulumix.Input[*string] `pulumi:"duration"`
+	// The maximum number of nodes that can be scaled down at any time.
+	Nodes pulumix.Input[*string] `pulumi:"nodes"`
+	// A cron schedule for when disruption can happen.
+	Schedule pulumix.Input[*string] `pulumi:"schedule"`
+}
+
+func (BudgetConfigArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*BudgetConfig)(nil)).Elem()
+}
+
+func (i BudgetConfigArgs) ToBudgetConfigOutput() BudgetConfigOutput {
+	return i.ToBudgetConfigOutputWithContext(context.Background())
+}
+
+func (i BudgetConfigArgs) ToBudgetConfigOutputWithContext(ctx context.Context) BudgetConfigOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(BudgetConfigOutput)
+}
+
+func (i *BudgetConfigArgs) ToOutput(ctx context.Context) pulumix.Output[*BudgetConfigArgs] {
+	return pulumix.Val(i)
+}
+
+// Configuration for Autoscaled Node budgets.
+type BudgetConfigOutput struct{ *pulumi.OutputState }
+
+func (BudgetConfigOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*BudgetConfig)(nil)).Elem()
+}
+
+func (o BudgetConfigOutput) ToBudgetConfigOutput() BudgetConfigOutput {
+	return o
+}
+
+func (o BudgetConfigOutput) ToBudgetConfigOutputWithContext(ctx context.Context) BudgetConfigOutput {
+	return o
+}
+
+func (o BudgetConfigOutput) ToOutput(ctx context.Context) pulumix.Output[BudgetConfig] {
+	return pulumix.Output[BudgetConfig]{
+		OutputState: o.OutputState,
+	}
+}
+
+// The duration during which disruptuon can happen.
+func (o BudgetConfigOutput) Duration() pulumix.Output[*string] {
+	return pulumix.Apply[BudgetConfig](o, func(v BudgetConfig) *string { return v.Duration })
+}
+
+// The maximum number of nodes that can be scaled down at any time.
+func (o BudgetConfigOutput) Nodes() pulumix.Output[*string] {
+	return pulumix.Apply[BudgetConfig](o, func(v BudgetConfig) *string { return v.Nodes })
+}
+
+// A cron schedule for when disruption can happen.
+func (o BudgetConfigOutput) Schedule() pulumix.Output[*string] {
+	return pulumix.Apply[BudgetConfig](o, func(v BudgetConfig) *string { return v.Schedule })
+}
+
 // Configuration for Autoscaled nodes disruption.
 type DisruptionConfig struct {
+	// Budgets control the speed Karpenter can scale down nodes.
+	Budgets []*BudgetConfig `pulumi:"budgets"`
 	// The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
 	ConsolidateAfter *string `pulumi:"consolidateAfter"`
 	// Describes which types of Nodes Karpenter should consider for consolidation.
@@ -30,10 +104,6 @@ func (val *DisruptionConfig) Defaults() *DisruptionConfig {
 		return nil
 	}
 	tmp := *val
-	if tmp.ConsolidateAfter == nil {
-		consolidateAfter_ := "30s"
-		tmp.ConsolidateAfter = &consolidateAfter_
-	}
 	if tmp.ConsolidationPolicy == nil {
 		consolidationPolicy_ := "WhenUnderutilized"
 		tmp.ConsolidationPolicy = &consolidationPolicy_
@@ -47,6 +117,8 @@ func (val *DisruptionConfig) Defaults() *DisruptionConfig {
 
 // Configuration for Autoscaled nodes disruption.
 type DisruptionConfigArgs struct {
+	// Budgets control the speed Karpenter can scale down nodes.
+	Budgets pulumix.Input[[]*BudgetConfigArgs] `pulumi:"budgets"`
 	// The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
 	ConsolidateAfter pulumix.Input[*string] `pulumi:"consolidateAfter"`
 	// Describes which types of Nodes Karpenter should consider for consolidation.
@@ -61,9 +133,6 @@ func (val *DisruptionConfigArgs) Defaults() *DisruptionConfigArgs {
 		return nil
 	}
 	tmp := *val
-	if tmp.ConsolidateAfter == nil {
-		tmp.ConsolidateAfter = pulumix.Ptr("30s")
-	}
 	if tmp.ConsolidationPolicy == nil {
 		tmp.ConsolidationPolicy = pulumix.Ptr("WhenUnderutilized")
 	}
@@ -107,6 +176,12 @@ func (o DisruptionConfigOutput) ToOutput(ctx context.Context) pulumix.Output[Dis
 	return pulumix.Output[DisruptionConfig]{
 		OutputState: o.OutputState,
 	}
+}
+
+// Budgets control the speed Karpenter can scale down nodes.
+func (o DisruptionConfigOutput) Budgets() pulumix.GArrayOutput[BudgetConfig, BudgetConfigOutput] {
+	value := pulumix.Apply[DisruptionConfig](o, func(v DisruptionConfig) []*BudgetConfig { return v.Budgets })
+	return pulumix.GArrayOutput[BudgetConfig, BudgetConfigOutput]{OutputState: value.OutputState}
 }
 
 // The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
@@ -353,6 +428,7 @@ type Taint struct {
 }
 
 func init() {
+	pulumi.RegisterOutputType(BudgetConfigOutput{})
 	pulumi.RegisterOutputType(DisruptionConfigOutput{})
 	pulumi.RegisterOutputType(IngressConfigOutput{})
 	pulumi.RegisterOutputType(RequirementOutput{})

--- a/sdk/go/eks/x/pulumiTypes.go
+++ b/sdk/go/eks/x/pulumiTypes.go
@@ -105,12 +105,8 @@ func (val *DisruptionConfig) Defaults() *DisruptionConfig {
 	}
 	tmp := *val
 	if tmp.ConsolidationPolicy == nil {
-		consolidationPolicy_ := "WhenUnderutilized"
+		consolidationPolicy_ := "WhenEmpty"
 		tmp.ConsolidationPolicy = &consolidationPolicy_
-	}
-	if tmp.ExpireAfter == nil {
-		expireAfter_ := "720h"
-		tmp.ExpireAfter = &expireAfter_
 	}
 	return &tmp
 }
@@ -134,10 +130,7 @@ func (val *DisruptionConfigArgs) Defaults() *DisruptionConfigArgs {
 	}
 	tmp := *val
 	if tmp.ConsolidationPolicy == nil {
-		tmp.ConsolidationPolicy = pulumix.Ptr("WhenUnderutilized")
-	}
-	if tmp.ExpireAfter == nil {
-		tmp.ExpireAfter = pulumix.Ptr("720h")
+		tmp.ConsolidationPolicy = pulumix.Ptr("WhenEmpty")
 	}
 	return &tmp
 }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -52,8 +52,7 @@ export interface DisruptionConfigArgs {
 export function disruptionConfigArgsProvideDefaults(val: DisruptionConfigArgs): DisruptionConfigArgs {
     return {
         ...val,
-        consolidationPolicy: (val.consolidationPolicy) ?? "WhenUnderutilized",
-        expireAfter: (val.expireAfter) ?? "720h",
+        consolidationPolicy: (val.consolidationPolicy) ?? "WhenEmpty",
     };
 }
 

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -8,9 +8,31 @@ import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
 /**
+ * Configuration for Autoscaled Node budgets.
+ */
+export interface BudgetConfigArgs {
+    /**
+     * The duration during which disruptuon can happen.
+     */
+    duration?: pulumi.Input<string>;
+    /**
+     * The maximum number of nodes that can be scaled down at any time.
+     */
+    nodes?: pulumi.Input<string>;
+    /**
+     * A cron schedule for when disruption can happen.
+     */
+    schedule?: pulumi.Input<string>;
+}
+
+/**
  * Configuration for Autoscaled nodes disruption.
  */
 export interface DisruptionConfigArgs {
+    /**
+     * Budgets control the speed Karpenter can scale down nodes.
+     */
+    budgets?: pulumi.Input<pulumi.Input<inputs.BudgetConfigArgs>[]>;
     /**
      * The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
      */
@@ -30,7 +52,6 @@ export interface DisruptionConfigArgs {
 export function disruptionConfigArgsProvideDefaults(val: DisruptionConfigArgs): DisruptionConfigArgs {
     return {
         ...val,
-        consolidateAfter: (val.consolidateAfter) ?? "30s",
         consolidationPolicy: (val.consolidationPolicy) ?? "WhenUnderutilized",
         expireAfter: (val.expireAfter) ?? "720h",
     };

--- a/sdk/python/lbrlabs_pulumi_eks/_inputs.py
+++ b/sdk/python/lbrlabs_pulumi_eks/_inputs.py
@@ -10,25 +10,84 @@ from typing import Any, Mapping, Optional, Sequence, Union, overload
 from . import _utilities
 
 __all__ = [
+    'BudgetConfigArgs',
     'DisruptionConfigArgs',
     'IngressConfigArgs',
     'RequirementArgs',
 ]
 
 @pulumi.input_type
+class BudgetConfigArgs:
+    def __init__(__self__, *,
+                 duration: Optional[pulumi.Input[str]] = None,
+                 nodes: Optional[pulumi.Input[str]] = None,
+                 schedule: Optional[pulumi.Input[str]] = None):
+        """
+        Configuration for Autoscaled Node budgets.
+        :param pulumi.Input[str] duration: The duration during which disruptuon can happen.
+        :param pulumi.Input[str] nodes: The maximum number of nodes that can be scaled down at any time.
+        :param pulumi.Input[str] schedule: A cron schedule for when disruption can happen.
+        """
+        if duration is not None:
+            pulumi.set(__self__, "duration", duration)
+        if nodes is not None:
+            pulumi.set(__self__, "nodes", nodes)
+        if schedule is not None:
+            pulumi.set(__self__, "schedule", schedule)
+
+    @property
+    @pulumi.getter
+    def duration(self) -> Optional[pulumi.Input[str]]:
+        """
+        The duration during which disruptuon can happen.
+        """
+        return pulumi.get(self, "duration")
+
+    @duration.setter
+    def duration(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "duration", value)
+
+    @property
+    @pulumi.getter
+    def nodes(self) -> Optional[pulumi.Input[str]]:
+        """
+        The maximum number of nodes that can be scaled down at any time.
+        """
+        return pulumi.get(self, "nodes")
+
+    @nodes.setter
+    def nodes(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "nodes", value)
+
+    @property
+    @pulumi.getter
+    def schedule(self) -> Optional[pulumi.Input[str]]:
+        """
+        A cron schedule for when disruption can happen.
+        """
+        return pulumi.get(self, "schedule")
+
+    @schedule.setter
+    def schedule(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "schedule", value)
+
+
+@pulumi.input_type
 class DisruptionConfigArgs:
     def __init__(__self__, *,
+                 budgets: Optional[pulumi.Input[Sequence[pulumi.Input['BudgetConfigArgs']]]] = None,
                  consolidate_after: Optional[pulumi.Input[str]] = None,
                  consolidation_policy: Optional[pulumi.Input[str]] = None,
                  expire_after: Optional[pulumi.Input[str]] = None):
         """
         Configuration for Autoscaled nodes disruption.
+        :param pulumi.Input[Sequence[pulumi.Input['BudgetConfigArgs']]] budgets: Budgets control the speed Karpenter can scale down nodes.
         :param pulumi.Input[str] consolidate_after: The amount of time Karpenter should wait after discovering a consolidation decision. This value can currently only be set when the consolidationPolicy is 'WhenEmpty'. You can choose to disable consolidation entirely by setting the string value 'Never' here.
         :param pulumi.Input[str] consolidation_policy: Describes which types of Nodes Karpenter should consider for consolidation.
         :param pulumi.Input[str] expire_after: The amount of time a Node can live on the cluster before being removed.
         """
-        if consolidate_after is None:
-            consolidate_after = '30s'
+        if budgets is not None:
+            pulumi.set(__self__, "budgets", budgets)
         if consolidate_after is not None:
             pulumi.set(__self__, "consolidate_after", consolidate_after)
         if consolidation_policy is None:
@@ -39,6 +98,18 @@ class DisruptionConfigArgs:
             expire_after = '720h'
         if expire_after is not None:
             pulumi.set(__self__, "expire_after", expire_after)
+
+    @property
+    @pulumi.getter
+    def budgets(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['BudgetConfigArgs']]]]:
+        """
+        Budgets control the speed Karpenter can scale down nodes.
+        """
+        return pulumi.get(self, "budgets")
+
+    @budgets.setter
+    def budgets(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['BudgetConfigArgs']]]]):
+        pulumi.set(self, "budgets", value)
 
     @property
     @pulumi.getter(name="consolidateAfter")

--- a/sdk/python/lbrlabs_pulumi_eks/_inputs.py
+++ b/sdk/python/lbrlabs_pulumi_eks/_inputs.py
@@ -91,11 +91,9 @@ class DisruptionConfigArgs:
         if consolidate_after is not None:
             pulumi.set(__self__, "consolidate_after", consolidate_after)
         if consolidation_policy is None:
-            consolidation_policy = 'WhenUnderutilized'
+            consolidation_policy = 'WhenEmpty'
         if consolidation_policy is not None:
             pulumi.set(__self__, "consolidation_policy", consolidation_policy)
-        if expire_after is None:
-            expire_after = '720h'
         if expire_after is not None:
             pulumi.set(__self__, "expire_after", expire_after)
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9edf4c6cfd3680263fc59b76488264dd0abdd7f5  | 
|--------|

### Summary:
This PR integrates budget configurations for autoscaled node groups, updates Karpenter, and expands SDK support, enhancing autoscaling functionalities.

**Key points**:
- Integrate `BudgetConfig` in `autoscaledNodegroup.go`
- Update Karpenter to `0.36.1` in `cluster.go`
- Add `BudgetConfig` schema definitions in `schema.yaml`
- Implement `BudgetConfig` in SDKs for .NET and Go
- Adjust default values and settings for node disruption and consolidation policies


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
