### PR TITLE
switch cluster access to API and Config map

### DIFF
--- a/provider/pkg/provider/cluster.go
+++ b/provider/pkg/provider/cluster.go
@@ -228,6 +228,9 @@ func NewCluster(ctx *pulumi.Context,
 	controlPlane, err := eks.NewCluster(ctx, name, &eks.ClusterArgs{
 		RoleArn: role.Arn,
 		Version: args.ClusterVersion,
+		AccessConfig: eks.ClusterAccessConfigArgs{
+			AuthenticationMode: pulumi.String("API_AND_CONFIG_MAP"),
+		},
 		VpcConfig: &eks.ClusterVpcConfigArgs{
 			SubnetIds:             args.ClusterSubnetIds,
 			EndpointPublicAccess:  args.ClusterEndpointPublicAccess,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f0f562e0b4d03b8e129c072e6b32900f83f37e55  | 
|--------|--------|

### Summary:
Updated cluster access configuration to enable both API and ConfigMap based authentication.

**Key points**:
- Updated `NewCluster` in `provider/pkg/provider/cluster.go` to set `AuthenticationMode` to `API_AND_CONFIG_MAP`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->