### PR TITLE
feat(EKS cluster configuration): add support for specifying Karpenter version

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -124,6 +124,10 @@ resources:
       clusterVersion:
         type: string
         description: The version of the EKS cluster to create.
+      karpenterVersion:
+        type: string
+        description: The version of karpenter to deploy.
+        default: "0.36.2"
       clusterEndpointPrivateAccess:
         type: boolean
         description: Indicates whether or not the Amazon EKS private API server endpoint is enabled.

--- a/sdk/dotnet/Eks/Cluster.cs
+++ b/sdk/dotnet/Eks/Cluster.cs
@@ -185,6 +185,12 @@ namespace Lbrlabs.PulumiPackage.Eks
         public Input<Inputs.IngressConfigArgs>? IngressConfig { get; set; }
 
         /// <summary>
+        /// The version of karpenter to deploy.
+        /// </summary>
+        [Input("karpenterVersion")]
+        public Input<string>? KarpenterVersion { get; set; }
+
+        /// <summary>
         /// The type of loadbalancer to provision.
         /// </summary>
         [Input("lbType")]
@@ -259,6 +265,7 @@ namespace Lbrlabs.PulumiPackage.Eks
             EnableInternalIngress = true;
             EnableKarpenter = true;
             EnableOtel = false;
+            KarpenterVersion = "0.36.2";
             LbType = "nlb";
         }
         public static new ClusterArgs Empty => new ClusterArgs();

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -81,6 +81,9 @@ func NewCluster(ctx *pulumi.Context,
 	if args.IngressConfig != nil {
 		args.IngressConfig = args.IngressConfig.ToIngressConfigPtrOutput().ApplyT(func(v *IngressConfig) *IngressConfig { return v.Defaults() }).(IngressConfigPtrOutput)
 	}
+	if args.KarpenterVersion == nil {
+		args.KarpenterVersion = pulumi.StringPtr("0.36.2")
+	}
 	if args.LbType == nil {
 		args.LbType = pulumi.StringPtr("nlb")
 	}
@@ -126,6 +129,8 @@ type clusterArgs struct {
 	ExternalDNSVersion *string `pulumi:"externalDNSVersion"`
 	// Configuration for the ingress controller.
 	IngressConfig *IngressConfig `pulumi:"ingressConfig"`
+	// The version of karpenter to deploy.
+	KarpenterVersion *string `pulumi:"karpenterVersion"`
 	// The type of loadbalancer to provision.
 	LbType *string `pulumi:"lbType"`
 	// The email address to use to issue certificates from Lets Encrypt.
@@ -178,6 +183,8 @@ type ClusterArgs struct {
 	ExternalDNSVersion pulumi.StringPtrInput
 	// Configuration for the ingress controller.
 	IngressConfig IngressConfigPtrInput
+	// The version of karpenter to deploy.
+	KarpenterVersion pulumi.StringPtrInput
 	// The type of loadbalancer to provision.
 	LbType pulumi.StringPtrInput
 	// The email address to use to issue certificates from Lets Encrypt.

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -82,6 +82,7 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["enabledClusterLogTypes"] = args ? args.enabledClusterLogTypes : undefined;
             resourceInputs["externalDNSVersion"] = args ? args.externalDNSVersion : undefined;
             resourceInputs["ingressConfig"] = args ? (args.ingressConfig ? pulumi.output(args.ingressConfig).apply(inputs.ingressConfigArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["karpenterVersion"] = (args ? args.karpenterVersion : undefined) ?? "0.36.2";
             resourceInputs["lbType"] = (args ? args.lbType : undefined) ?? "nlb";
             resourceInputs["letsEncryptEmail"] = args ? args.letsEncryptEmail : undefined;
             resourceInputs["nginxIngressVersion"] = args ? args.nginxIngressVersion : undefined;
@@ -176,6 +177,10 @@ export interface ClusterArgs {
      * Configuration for the ingress controller.
      */
     ingressConfig?: pulumi.Input<inputs.IngressConfigArgs>;
+    /**
+     * The version of karpenter to deploy.
+     */
+    karpenterVersion?: pulumi.Input<string>;
     /**
      * The type of loadbalancer to provision.
      */

--- a/sdk/python/lbrlabs_pulumi_eks/cluster.py
+++ b/sdk/python/lbrlabs_pulumi_eks/cluster.py
@@ -34,6 +34,7 @@ class ClusterArgs:
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  external_dns_version: Optional[pulumi.Input[str]] = None,
                  ingress_config: Optional[pulumi.Input['IngressConfigArgs']] = None,
+                 karpenter_version: Optional[pulumi.Input[str]] = None,
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
@@ -59,6 +60,7 @@ class ClusterArgs:
         :param bool enable_otel: Whether to enable the OTEL Distro for EKS.
         :param pulumi.Input[str] external_dns_version: The version of the external-dns helm chart to deploy.
         :param pulumi.Input['IngressConfigArgs'] ingress_config: Configuration for the ingress controller.
+        :param pulumi.Input[str] karpenter_version: The version of karpenter to deploy.
         :param pulumi.Input[str] lb_type: The type of loadbalancer to provision.
         :param str lets_encrypt_email: The email address to use to issue certificates from Lets Encrypt.
         :param pulumi.Input[str] nginx_ingress_version: The version of the nginx ingress controller helm chart to deploy.
@@ -119,6 +121,10 @@ class ClusterArgs:
             pulumi.set(__self__, "external_dns_version", external_dns_version)
         if ingress_config is not None:
             pulumi.set(__self__, "ingress_config", ingress_config)
+        if karpenter_version is None:
+            karpenter_version = '0.36.2'
+        if karpenter_version is not None:
+            pulumi.set(__self__, "karpenter_version", karpenter_version)
         if lb_type is None:
             lb_type = 'nlb'
         if lb_type is not None:
@@ -346,6 +352,18 @@ class ClusterArgs:
         pulumi.set(self, "ingress_config", value)
 
     @property
+    @pulumi.getter(name="karpenterVersion")
+    def karpenter_version(self) -> Optional[pulumi.Input[str]]:
+        """
+        The version of karpenter to deploy.
+        """
+        return pulumi.get(self, "karpenter_version")
+
+    @karpenter_version.setter
+    def karpenter_version(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "karpenter_version", value)
+
+    @property
     @pulumi.getter(name="lbType")
     def lb_type(self) -> Optional[pulumi.Input[str]]:
         """
@@ -461,6 +479,7 @@ class Cluster(pulumi.ComponentResource):
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  external_dns_version: Optional[pulumi.Input[str]] = None,
                  ingress_config: Optional[pulumi.Input[pulumi.InputType['IngressConfigArgs']]] = None,
+                 karpenter_version: Optional[pulumi.Input[str]] = None,
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
@@ -490,6 +509,7 @@ class Cluster(pulumi.ComponentResource):
         :param bool enable_otel: Whether to enable the OTEL Distro for EKS.
         :param pulumi.Input[str] external_dns_version: The version of the external-dns helm chart to deploy.
         :param pulumi.Input[pulumi.InputType['IngressConfigArgs']] ingress_config: Configuration for the ingress controller.
+        :param pulumi.Input[str] karpenter_version: The version of karpenter to deploy.
         :param pulumi.Input[str] lb_type: The type of loadbalancer to provision.
         :param str lets_encrypt_email: The email address to use to issue certificates from Lets Encrypt.
         :param pulumi.Input[str] nginx_ingress_version: The version of the nginx ingress controller helm chart to deploy.
@@ -538,6 +558,7 @@ class Cluster(pulumi.ComponentResource):
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  external_dns_version: Optional[pulumi.Input[str]] = None,
                  ingress_config: Optional[pulumi.Input[pulumi.InputType['IngressConfigArgs']]] = None,
+                 karpenter_version: Optional[pulumi.Input[str]] = None,
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
@@ -595,6 +616,9 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["enabled_cluster_log_types"] = enabled_cluster_log_types
             __props__.__dict__["external_dns_version"] = external_dns_version
             __props__.__dict__["ingress_config"] = ingress_config
+            if karpenter_version is None:
+                karpenter_version = '0.36.2'
+            __props__.__dict__["karpenter_version"] = karpenter_version
             if lb_type is None:
                 lb_type = 'nlb'
             __props__.__dict__["lb_type"] = lb_type


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit dce762c7725c80138a89297efdb6d80ccba7be6c  | 
|--------|--------|

### Summary:
Added support for specifying the Karpenter version in the EKS cluster configuration across multiple SDKs.

**Key points**:
- **Added** `karpenterVersion` parameter to `ClusterArgs` in `provider/pkg/provider/cluster.go`.
- **Updated** CRD URLs in `NewCluster` function to use `karpenterVersion` in `provider/pkg/provider/cluster.go`.
- **Modified** `schema.yaml` to include `karpenterVersion` with a default value of `0.36.2`.
- **Updated** .NET SDK in `sdk/dotnet/Eks/Cluster.cs` to include `KarpenterVersion` property.
- **Updated** Go SDK in `sdk/go/eks/cluster.go` to include `KarpenterVersion` property.
- **Updated** Node.js SDK in `sdk/nodejs/cluster.ts` to include `karpenterVersion` property.
- **Updated** Python SDK in `sdk/python/lbrlabs_pulumi_eks/cluster.py` to include `karpenter_version` property.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->