### PR TITLE
feat(autoscaledNodeGroup): add support for custom AMI ID

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -403,6 +403,9 @@ resources:
       amiFamily:
         type: string
         description: "AMI family for the node group."
+      amiId:
+        type: string
+        description: "AMI ID for the node group."
       nodeRole:
         type: string
         description: "Node role for the node group."

--- a/sdk/dotnet/Eks/AutoscaledNodeGroup.cs
+++ b/sdk/dotnet/Eks/AutoscaledNodeGroup.cs
@@ -47,6 +47,12 @@ namespace Lbrlabs.PulumiPackage.Eks
         [Input("amiFamily")]
         public Input<string>? AmiFamily { get; set; }
 
+        /// <summary>
+        /// AMI ID for the node group.
+        /// </summary>
+        [Input("amiId")]
+        public Input<string>? AmiId { get; set; }
+
         [Input("annotations")]
         private InputMap<string>? _annotations;
 

--- a/sdk/go/eks/autoscaledNodeGroup.go
+++ b/sdk/go/eks/autoscaledNodeGroup.go
@@ -54,6 +54,8 @@ func NewAutoscaledNodeGroup(ctx *pulumi.Context,
 type autoscaledNodeGroupArgs struct {
 	// AMI family for the node group.
 	AmiFamily *string `pulumi:"amiFamily"`
+	// AMI ID for the node group.
+	AmiId *string `pulumi:"amiId"`
 	// Annotations to apply to the node group.
 	Annotations map[string]string `pulumi:"annotations"`
 	// Disk size for the node group.
@@ -77,6 +79,8 @@ type autoscaledNodeGroupArgs struct {
 type AutoscaledNodeGroupArgs struct {
 	// AMI family for the node group.
 	AmiFamily pulumi.StringPtrInput
+	// AMI ID for the node group.
+	AmiId pulumi.StringPtrInput
 	// Annotations to apply to the node group.
 	Annotations pulumi.StringMapInput
 	// Disk size for the node group.

--- a/sdk/nodejs/autoscaledNodeGroup.ts
+++ b/sdk/nodejs/autoscaledNodeGroup.ts
@@ -51,6 +51,7 @@ export class AutoscaledNodeGroup extends pulumi.ComponentResource {
                 throw new Error("Missing required property 'subnetIds'");
             }
             resourceInputs["amiFamily"] = args ? args.amiFamily : undefined;
+            resourceInputs["amiId"] = args ? args.amiId : undefined;
             resourceInputs["annotations"] = args ? args.annotations : undefined;
             resourceInputs["diskSize"] = (args ? args.diskSize : undefined) ?? "20Gi";
             resourceInputs["disruption"] = args ? (args.disruption ? pulumi.output(args.disruption).apply(inputs.disruptionConfigArgsProvideDefaults) : undefined) : undefined;
@@ -75,6 +76,10 @@ export interface AutoscaledNodeGroupArgs {
      * AMI family for the node group.
      */
     amiFamily?: pulumi.Input<string>;
+    /**
+     * AMI ID for the node group.
+     */
+    amiId?: pulumi.Input<string>;
     /**
      * Annotations to apply to the node group.
      */

--- a/sdk/python/lbrlabs_pulumi_eks/autoscaled_node_group.py
+++ b/sdk/python/lbrlabs_pulumi_eks/autoscaled_node_group.py
@@ -22,6 +22,7 @@ class AutoscaledNodeGroupArgs:
                  security_group_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
                  subnet_ids: pulumi.Input[Sequence[pulumi.Input[str]]],
                  ami_family: Optional[pulumi.Input[str]] = None,
+                 ami_id: Optional[pulumi.Input[str]] = None,
                  annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  disruption: Optional[pulumi.Input['DisruptionConfigArgs']] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -34,6 +35,7 @@ class AutoscaledNodeGroupArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] security_group_ids: List of security group selector terms for the node group.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: List of subnet selector terms for the node group.
         :param pulumi.Input[str] ami_family: AMI family for the node group.
+        :param pulumi.Input[str] ami_id: AMI ID for the node group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] annotations: Annotations to apply to the node group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.core.v1.TaintArgs']]] taints: Optional node taints.
@@ -47,6 +49,8 @@ class AutoscaledNodeGroupArgs:
         pulumi.set(__self__, "subnet_ids", subnet_ids)
         if ami_family is not None:
             pulumi.set(__self__, "ami_family", ami_family)
+        if ami_id is not None:
+            pulumi.set(__self__, "ami_id", ami_id)
         if annotations is not None:
             pulumi.set(__self__, "annotations", annotations)
         if disruption is not None:
@@ -129,6 +133,18 @@ class AutoscaledNodeGroupArgs:
         pulumi.set(self, "ami_family", value)
 
     @property
+    @pulumi.getter(name="amiId")
+    def ami_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        AMI ID for the node group.
+        """
+        return pulumi.get(self, "ami_id")
+
+    @ami_id.setter
+    def ami_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "ami_id", value)
+
+    @property
     @pulumi.getter
     def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         """
@@ -180,6 +196,7 @@ class AutoscaledNodeGroup(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  ami_family: Optional[pulumi.Input[str]] = None,
+                 ami_id: Optional[pulumi.Input[str]] = None,
                  annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  disk_size: Optional[pulumi.Input[str]] = None,
                  disruption: Optional[pulumi.Input[pulumi.InputType['DisruptionConfigArgs']]] = None,
@@ -195,6 +212,7 @@ class AutoscaledNodeGroup(pulumi.ComponentResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] ami_family: AMI family for the node group.
+        :param pulumi.Input[str] ami_id: AMI ID for the node group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] annotations: Annotations to apply to the node group.
         :param pulumi.Input[str] disk_size: Disk size for the node group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
@@ -228,6 +246,7 @@ class AutoscaledNodeGroup(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  ami_family: Optional[pulumi.Input[str]] = None,
+                 ami_id: Optional[pulumi.Input[str]] = None,
                  annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  disk_size: Optional[pulumi.Input[str]] = None,
                  disruption: Optional[pulumi.Input[pulumi.InputType['DisruptionConfigArgs']]] = None,
@@ -249,6 +268,7 @@ class AutoscaledNodeGroup(pulumi.ComponentResource):
             __props__ = AutoscaledNodeGroupArgs.__new__(AutoscaledNodeGroupArgs)
 
             __props__.__dict__["ami_family"] = ami_family
+            __props__.__dict__["ami_id"] = ami_id
             __props__.__dict__["annotations"] = annotations
             if disk_size is None:
                 disk_size = '20Gi'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ba8e20296a3ba9364a161a99ac84e986c26e2c73  | 
|--------|--------|

### Summary:
Added support for specifying a custom AMI ID in the autoscaled node group for the Pulumi EKS provider.

**Key points**:
- Added `amiId` parameter to `AutoscaledNodeGroupArgs` in `provider/pkg/provider/autoscaledNodegroup.go`
- Updated schema in `schema.yaml` to include `amiId` for `AutoscaledNodeGroup`
- Modified `AutoscaledNodeGroup` classes in SDKs:
  - .NET: `sdk/dotnet/Eks/AutoscaledNodeGroup.cs`
  - Go: `sdk/go/eks/autoscaledNodeGroup.go`
  - Node.js: `sdk/nodejs/autoscaledNodeGroup.ts`
  - Python: `sdk/python/lbrlabs_pulumi_eks/autoscaled_node_group.py`
- `amiId` allows specifying a custom AMI ID for the node group


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->