### PR TITLE
feat(provider): add NginxIngressRegistry parameter for Nginx Ingress Controller registry configuration

### DIFF
--- a/provider/pkg/provider/cluster.go
+++ b/provider/pkg/provider/cluster.go
@@ -60,6 +60,7 @@ type ClusterArgs struct {
 	CertificateArn               *pulumi.StringInput      `pulumi:"certificateArn"`
 	Tags                         *pulumi.StringMapInput   `pulumi:"tags"`
 	NginxIngressVersion          pulumi.StringInput       `pulumi:"nginxIngressVersion"`
+	NginxIngressRegistry         pulumi.StringInput       `pulumi:"nginxIngressRegistry"`
 	EksIamAuthControllerVersion  pulumi.StringInput       `pulumi:"eksIamAuthControllerVersion"`
 	ExternalDNSVersion           pulumi.StringInput       `pulumi:"externalDNSVersion"`
 	CertManagerVersion           pulumi.StringInput       `pulumi:"certManagerVersion"`
@@ -653,6 +654,9 @@ func NewCluster(ctx *pulumi.Context,
 			},
 			Values: pulumi.Map{
 				"controller": pulumi.Map{
+					"image": pulumi.Map{
+						"registry": args.NginxIngressRegistry,
+					},
 					"metrics": pulumi.Map{
 						"enabled": realisedIngressConfig.EnableMetrics,
 						"serviceMonitor": pulumi.Map{
@@ -664,6 +668,9 @@ func NewCluster(ctx *pulumi.Context,
 					"replicaCount": realisedIngressConfig.ControllerReplicas,
 					"admissionWebhooks": pulumi.Map{
 						"patch": pulumi.Map{
+							"image": pulumi.Map{
+								"registry": args.NginxIngressRegistry,
+							},
 							"tolerations": pulumi.MapArray{
 								pulumi.Map{
 									"key":      pulumi.String("node.lbrlabs.com/system"),
@@ -693,6 +700,9 @@ func NewCluster(ctx *pulumi.Context,
 					},
 				},
 				"defaultBackend": pulumi.Map{
+					"image": pulumi.Map{
+						"registry": args.NginxIngressRegistry,
+					},
 					"tolerations": pulumi.MapArray{
 						pulumi.Map{
 							"key":      pulumi.String("node.lbrlabs.com/system"),

--- a/schema.yaml
+++ b/schema.yaml
@@ -145,6 +145,10 @@ resources:
       nginxIngressVersion:
         type: string
         description: The version of the nginx ingress controller helm chart to deploy.
+      nginxIngressRegistry:
+        type: string
+        description: The container registry to pull images from.
+        default: "registry.k8s.io"
       eksIamAuthControllerVersion:
         type: string
         description: The version of the eks-iam-auth-controller helm chart to deploy.

--- a/sdk/dotnet/Eks/Cluster.cs
+++ b/sdk/dotnet/Eks/Cluster.cs
@@ -209,6 +209,12 @@ namespace Lbrlabs.PulumiPackage.Eks
         public string? LetsEncryptEmail { get; set; }
 
         /// <summary>
+        /// The container registry to pull images from.
+        /// </summary>
+        [Input("nginxIngressRegistry")]
+        public Input<string>? NginxIngressRegistry { get; set; }
+
+        /// <summary>
         /// The version of the nginx ingress controller helm chart to deploy.
         /// </summary>
         [Input("nginxIngressVersion")]
@@ -273,6 +279,7 @@ namespace Lbrlabs.PulumiPackage.Eks
             EnableOtel = false;
             KarpenterVersion = "0.36.2";
             LbType = "nlb";
+            NginxIngressRegistry = "registry.k8s.io";
         }
         public static new ClusterArgs Empty => new ClusterArgs();
     }

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -87,6 +87,9 @@ func NewCluster(ctx *pulumi.Context,
 	if args.LbType == nil {
 		args.LbType = pulumi.StringPtr("nlb")
 	}
+	if args.NginxIngressRegistry == nil {
+		args.NginxIngressRegistry = pulumi.StringPtr("registry.k8s.io")
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Cluster
 	err := ctx.RegisterRemoteComponentResource("lbrlabs-eks:index:Cluster", name, args, &resource, opts...)
@@ -137,6 +140,8 @@ type clusterArgs struct {
 	LbType *string `pulumi:"lbType"`
 	// The email address to use to issue certificates from Lets Encrypt.
 	LetsEncryptEmail *string `pulumi:"letsEncryptEmail"`
+	// The container registry to pull images from.
+	NginxIngressRegistry *string `pulumi:"nginxIngressRegistry"`
 	// The version of the nginx ingress controller helm chart to deploy.
 	NginxIngressVersion *string `pulumi:"nginxIngressVersion"`
 	// The initial number of nodes in the system autoscaling group.
@@ -193,6 +198,8 @@ type ClusterArgs struct {
 	LbType pulumi.StringPtrInput
 	// The email address to use to issue certificates from Lets Encrypt.
 	LetsEncryptEmail *string
+	// The container registry to pull images from.
+	NginxIngressRegistry pulumi.StringPtrInput
 	// The version of the nginx ingress controller helm chart to deploy.
 	NginxIngressVersion pulumi.StringPtrInput
 	// The initial number of nodes in the system autoscaling group.

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -86,6 +86,7 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["karpenterVersion"] = (args ? args.karpenterVersion : undefined) ?? "0.36.2";
             resourceInputs["lbType"] = (args ? args.lbType : undefined) ?? "nlb";
             resourceInputs["letsEncryptEmail"] = args ? args.letsEncryptEmail : undefined;
+            resourceInputs["nginxIngressRegistry"] = (args ? args.nginxIngressRegistry : undefined) ?? "registry.k8s.io";
             resourceInputs["nginxIngressVersion"] = args ? args.nginxIngressVersion : undefined;
             resourceInputs["systemNodeDesiredCount"] = args ? args.systemNodeDesiredCount : undefined;
             resourceInputs["systemNodeInstanceTypes"] = args ? args.systemNodeInstanceTypes : undefined;
@@ -194,6 +195,10 @@ export interface ClusterArgs {
      * The email address to use to issue certificates from Lets Encrypt.
      */
     letsEncryptEmail?: string;
+    /**
+     * The container registry to pull images from.
+     */
+    nginxIngressRegistry?: pulumi.Input<string>;
     /**
      * The version of the nginx ingress controller helm chart to deploy.
      */

--- a/sdk/python/lbrlabs_pulumi_eks/cluster.py
+++ b/sdk/python/lbrlabs_pulumi_eks/cluster.py
@@ -38,6 +38,7 @@ class ClusterArgs:
                  karpenter_version: Optional[pulumi.Input[str]] = None,
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
+                 nginx_ingress_registry: Optional[pulumi.Input[str]] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
                  system_node_desired_count: Optional[pulumi.Input[float]] = None,
                  system_node_instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -65,6 +66,7 @@ class ClusterArgs:
         :param pulumi.Input[str] karpenter_version: The version of karpenter to deploy.
         :param pulumi.Input[str] lb_type: The type of loadbalancer to provision.
         :param str lets_encrypt_email: The email address to use to issue certificates from Lets Encrypt.
+        :param pulumi.Input[str] nginx_ingress_registry: The container registry to pull images from.
         :param pulumi.Input[str] nginx_ingress_version: The version of the nginx ingress controller helm chart to deploy.
         :param pulumi.Input[float] system_node_desired_count: The initial number of nodes in the system autoscaling group.
         :param pulumi.Input[float] system_node_max_count: The maximum number of nodes in the system autoscaling group.
@@ -135,6 +137,10 @@ class ClusterArgs:
             pulumi.set(__self__, "lb_type", lb_type)
         if lets_encrypt_email is not None:
             pulumi.set(__self__, "lets_encrypt_email", lets_encrypt_email)
+        if nginx_ingress_registry is None:
+            nginx_ingress_registry = 'registry.k8s.io'
+        if nginx_ingress_registry is not None:
+            pulumi.set(__self__, "nginx_ingress_registry", nginx_ingress_registry)
         if nginx_ingress_version is not None:
             pulumi.set(__self__, "nginx_ingress_version", nginx_ingress_version)
         if system_node_desired_count is not None:
@@ -404,6 +410,18 @@ class ClusterArgs:
         pulumi.set(self, "lets_encrypt_email", value)
 
     @property
+    @pulumi.getter(name="nginxIngressRegistry")
+    def nginx_ingress_registry(self) -> Optional[pulumi.Input[str]]:
+        """
+        The container registry to pull images from.
+        """
+        return pulumi.get(self, "nginx_ingress_registry")
+
+    @nginx_ingress_registry.setter
+    def nginx_ingress_registry(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "nginx_ingress_registry", value)
+
+    @property
     @pulumi.getter(name="nginxIngressVersion")
     def nginx_ingress_version(self) -> Optional[pulumi.Input[str]]:
         """
@@ -499,6 +517,7 @@ class Cluster(pulumi.ComponentResource):
                  karpenter_version: Optional[pulumi.Input[str]] = None,
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
+                 nginx_ingress_registry: Optional[pulumi.Input[str]] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
                  system_node_desired_count: Optional[pulumi.Input[float]] = None,
                  system_node_instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -530,6 +549,7 @@ class Cluster(pulumi.ComponentResource):
         :param pulumi.Input[str] karpenter_version: The version of karpenter to deploy.
         :param pulumi.Input[str] lb_type: The type of loadbalancer to provision.
         :param str lets_encrypt_email: The email address to use to issue certificates from Lets Encrypt.
+        :param pulumi.Input[str] nginx_ingress_registry: The container registry to pull images from.
         :param pulumi.Input[str] nginx_ingress_version: The version of the nginx ingress controller helm chart to deploy.
         :param pulumi.Input[float] system_node_desired_count: The initial number of nodes in the system autoscaling group.
         :param pulumi.Input[float] system_node_max_count: The maximum number of nodes in the system autoscaling group.
@@ -580,6 +600,7 @@ class Cluster(pulumi.ComponentResource):
                  karpenter_version: Optional[pulumi.Input[str]] = None,
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
+                 nginx_ingress_registry: Optional[pulumi.Input[str]] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
                  system_node_desired_count: Optional[pulumi.Input[float]] = None,
                  system_node_instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -643,6 +664,9 @@ class Cluster(pulumi.ComponentResource):
                 lb_type = 'nlb'
             __props__.__dict__["lb_type"] = lb_type
             __props__.__dict__["lets_encrypt_email"] = lets_encrypt_email
+            if nginx_ingress_registry is None:
+                nginx_ingress_registry = 'registry.k8s.io'
+            __props__.__dict__["nginx_ingress_registry"] = nginx_ingress_registry
             __props__.__dict__["nginx_ingress_version"] = nginx_ingress_version
             __props__.__dict__["system_node_desired_count"] = system_node_desired_count
             __props__.__dict__["system_node_instance_types"] = system_node_instance_types


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 34649861e2b7c9ce961ba3900f8fa363b1ed6f1d  | 
|--------|--------|

### Summary:
Introduced `NginxIngressRegistry` parameter to specify the container registry for Nginx Ingress Controller, with updates across all language SDKs and schema.

**Key points**:
- Added `NginxIngressRegistry` to `ClusterArgs` in `provider/pkg/provider/cluster.go`.
- Default value for `NginxIngressRegistry` is `registry.k8s.io`.
- Updated `NewCluster` function to use `NginxIngressRegistry` for Nginx Ingress Controller image registry.
- Reflected changes in `schema.yaml` with description and default value.
- Updated .NET, Go, Node.js, and Python SDKs to include `NginxIngressRegistry`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->