### PR TITLE
feat: add `apiVersion` to `AutoscaledNodeGroup` for Karpenter API versioning

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1019,6 +1019,7 @@ github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813/go.mod h1:P+oSoE9yhSRvsmYyZsshflcR6ePWYLql6UU1amW13IM=
 github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
@@ -1052,6 +1053,7 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-sql-driver/mysql v1.8.0/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
+github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-zookeeper/zk v1.0.3/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
@@ -1274,6 +1276,7 @@ github.com/onsi/ginkgo/v2 v2.1.6/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7
 github.com/onsi/ginkgo/v2 v2.3.0/go.mod h1:Eew0uilEqZmIEZr8JrvYlvOM7Rr6xzTmMV8AyFNU9d0=
 github.com/onsi/ginkgo/v2 v2.4.0/go.mod h1:iHkDK1fKGcBoEHT5W7YBq4RFWaQulw+caOMkAt4OrFo=
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
+github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=

--- a/provider/pkg/provider/autoscaledNodegroup.go
+++ b/provider/pkg/provider/autoscaledNodegroup.go
@@ -22,6 +22,7 @@ type DisruptionConfig struct {
 
 type AutoscaledNodeGroupArgs struct {
 	Annotations      *pulumi.StringMapInput  `pulumi:"annotations"`
+	ApiVersion       pulumi.StringInput      `pulumi:"apiVersion"`
 	AMIFamily        *pulumi.StringInput     `pulumi:"amiFamily"`
 	AmiID            *pulumi.StringInput     `pulumi:"amiId"`
 	DiskSize         pulumi.StringInput      `pulumi:"diskSize"`
@@ -141,7 +142,7 @@ func NewAutoscaledNodeGroup(ctx *pulumi.Context,
 	}
 
 	nodeClass, err := apiextensions.NewCustomResource(ctx, fmt.Sprintf("%s-nodeclass", name), &apiextensions.CustomResourceArgs{
-		ApiVersion: pulumi.String("karpenter.k8s.aws/v1beta1"),
+		ApiVersion: pulumi.Sprintf("karpenter.sh/%s", args.ApiVersion),
 		Kind:       pulumi.String("EC2NodeClass"),
 		Metadata: metav1.ObjectMetaArgs{
 			Annotations: annotations,
@@ -164,7 +165,7 @@ func NewAutoscaledNodeGroup(ctx *pulumi.Context,
 	}
 
 	_, err = apiextensions.NewCustomResource(ctx, fmt.Sprintf("%s-nodepool", name), &apiextensions.CustomResourceArgs{
-		ApiVersion: pulumi.String("karpenter.sh/v1beta1"),
+		ApiVersion: pulumi.Sprintf("karpenter.sh/%s", args.ApiVersion),
 		Kind:       pulumi.String("NodePool"),
 		Metadata: metav1.ObjectMetaArgs{
 			Annotations: annotations,

--- a/schema.yaml
+++ b/schema.yaml
@@ -413,6 +413,10 @@ resources:
       nodeRole:
         type: string
         description: "Node role for the node group."
+      apiVersion:
+        type: string
+        description: "Karpenter API version."
+        default: "v1"
       diskSize:
         type: string
         description: "Disk size for the node group."

--- a/sdk/dotnet/Eks/AutoscaledNodeGroup.cs
+++ b/sdk/dotnet/Eks/AutoscaledNodeGroup.cs
@@ -66,6 +66,12 @@ namespace Lbrlabs.PulumiPackage.Eks
         }
 
         /// <summary>
+        /// Karpenter API version.
+        /// </summary>
+        [Input("apiVersion")]
+        public Input<string>? ApiVersion { get; set; }
+
+        /// <summary>
         /// Disk size for the node group.
         /// </summary>
         [Input("diskSize", required: true)]
@@ -142,6 +148,7 @@ namespace Lbrlabs.PulumiPackage.Eks
 
         public AutoscaledNodeGroupArgs()
         {
+            ApiVersion = "v1";
             DiskSize = "20Gi";
         }
         public static new AutoscaledNodeGroupArgs Empty => new AutoscaledNodeGroupArgs();

--- a/sdk/go/eks/autoscaledNodeGroup.go
+++ b/sdk/go/eks/autoscaledNodeGroup.go
@@ -36,6 +36,9 @@ func NewAutoscaledNodeGroup(ctx *pulumi.Context,
 	if args.SubnetIds == nil {
 		return nil, errors.New("invalid value for required argument 'SubnetIds'")
 	}
+	if args.ApiVersion == nil {
+		args.ApiVersion = pulumi.StringPtr("v1")
+	}
 	if args.DiskSize == nil {
 		args.DiskSize = pulumi.String("20Gi")
 	}
@@ -58,6 +61,8 @@ type autoscaledNodeGroupArgs struct {
 	AmiId *string `pulumi:"amiId"`
 	// Annotations to apply to the node group.
 	Annotations map[string]string `pulumi:"annotations"`
+	// Karpenter API version.
+	ApiVersion *string `pulumi:"apiVersion"`
 	// Disk size for the node group.
 	DiskSize   string            `pulumi:"diskSize"`
 	Disruption *DisruptionConfig `pulumi:"disruption"`
@@ -83,6 +88,8 @@ type AutoscaledNodeGroupArgs struct {
 	AmiId pulumi.StringPtrInput
 	// Annotations to apply to the node group.
 	Annotations pulumi.StringMapInput
+	// Karpenter API version.
+	ApiVersion pulumi.StringPtrInput
 	// Disk size for the node group.
 	DiskSize   pulumi.StringInput
 	Disruption DisruptionConfigPtrInput

--- a/sdk/nodejs/autoscaledNodeGroup.ts
+++ b/sdk/nodejs/autoscaledNodeGroup.ts
@@ -53,6 +53,7 @@ export class AutoscaledNodeGroup extends pulumi.ComponentResource {
             resourceInputs["amiFamily"] = args ? args.amiFamily : undefined;
             resourceInputs["amiId"] = args ? args.amiId : undefined;
             resourceInputs["annotations"] = args ? args.annotations : undefined;
+            resourceInputs["apiVersion"] = (args ? args.apiVersion : undefined) ?? "v1";
             resourceInputs["diskSize"] = (args ? args.diskSize : undefined) ?? "20Gi";
             resourceInputs["disruption"] = args ? (args.disruption ? pulumi.output(args.disruption).apply(inputs.disruptionConfigArgsProvideDefaults) : undefined) : undefined;
             resourceInputs["labels"] = args ? args.labels : undefined;
@@ -84,6 +85,10 @@ export interface AutoscaledNodeGroupArgs {
      * Annotations to apply to the node group.
      */
     annotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    /**
+     * Karpenter API version.
+     */
+    apiVersion?: pulumi.Input<string>;
     /**
      * Disk size for the node group.
      */

--- a/sdk/python/lbrlabs_pulumi_eks/autoscaled_node_group.py
+++ b/sdk/python/lbrlabs_pulumi_eks/autoscaled_node_group.py
@@ -29,6 +29,7 @@ class AutoscaledNodeGroupArgs:
                  ami_family: Optional[pulumi.Input[str]] = None,
                  ami_id: Optional[pulumi.Input[str]] = None,
                  annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 api_version: Optional[pulumi.Input[str]] = None,
                  disruption: Optional[pulumi.Input['DisruptionConfigArgs']] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  taints: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.core.v1.TaintArgs']]]] = None):
@@ -42,6 +43,7 @@ class AutoscaledNodeGroupArgs:
         :param pulumi.Input[str] ami_family: AMI family for the node group.
         :param pulumi.Input[str] ami_id: AMI ID for the node group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] annotations: Annotations to apply to the node group.
+        :param pulumi.Input[str] api_version: Karpenter API version.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.core.v1.TaintArgs']]] taints: Optional node taints.
         """
@@ -58,6 +60,10 @@ class AutoscaledNodeGroupArgs:
             pulumi.set(__self__, "ami_id", ami_id)
         if annotations is not None:
             pulumi.set(__self__, "annotations", annotations)
+        if api_version is None:
+            api_version = 'v1'
+        if api_version is not None:
+            pulumi.set(__self__, "api_version", api_version)
         if disruption is not None:
             pulumi.set(__self__, "disruption", disruption)
         if labels is not None:
@@ -162,6 +168,18 @@ class AutoscaledNodeGroupArgs:
         pulumi.set(self, "annotations", value)
 
     @property
+    @pulumi.getter(name="apiVersion")
+    def api_version(self) -> Optional[pulumi.Input[str]]:
+        """
+        Karpenter API version.
+        """
+        return pulumi.get(self, "api_version")
+
+    @api_version.setter
+    def api_version(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "api_version", value)
+
+    @property
     @pulumi.getter
     def disruption(self) -> Optional[pulumi.Input['DisruptionConfigArgs']]:
         return pulumi.get(self, "disruption")
@@ -203,6 +221,7 @@ class AutoscaledNodeGroup(pulumi.ComponentResource):
                  ami_family: Optional[pulumi.Input[str]] = None,
                  ami_id: Optional[pulumi.Input[str]] = None,
                  annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 api_version: Optional[pulumi.Input[str]] = None,
                  disk_size: Optional[pulumi.Input[str]] = None,
                  disruption: Optional[pulumi.Input[Union['DisruptionConfigArgs', 'DisruptionConfigArgsDict']]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -219,6 +238,7 @@ class AutoscaledNodeGroup(pulumi.ComponentResource):
         :param pulumi.Input[str] ami_family: AMI family for the node group.
         :param pulumi.Input[str] ami_id: AMI ID for the node group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] annotations: Annotations to apply to the node group.
+        :param pulumi.Input[str] api_version: Karpenter API version.
         :param pulumi.Input[str] disk_size: Disk size for the node group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
         :param pulumi.Input[str] node_role: Node role for the node group.
@@ -253,6 +273,7 @@ class AutoscaledNodeGroup(pulumi.ComponentResource):
                  ami_family: Optional[pulumi.Input[str]] = None,
                  ami_id: Optional[pulumi.Input[str]] = None,
                  annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 api_version: Optional[pulumi.Input[str]] = None,
                  disk_size: Optional[pulumi.Input[str]] = None,
                  disruption: Optional[pulumi.Input[Union['DisruptionConfigArgs', 'DisruptionConfigArgsDict']]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -275,6 +296,9 @@ class AutoscaledNodeGroup(pulumi.ComponentResource):
             __props__.__dict__["ami_family"] = ami_family
             __props__.__dict__["ami_id"] = ami_id
             __props__.__dict__["annotations"] = annotations
+            if api_version is None:
+                api_version = 'v1'
+            __props__.__dict__["api_version"] = api_version
             if disk_size is None:
                 disk_size = '20Gi'
             if disk_size is None and not opts.urn:


### PR DESCRIPTION
Signed-off-by: Lee Briggs <lee@leebriggs.co.uk>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `apiVersion` field to `AutoscaledNodeGroup` for specifying Karpenter API version, defaulting to `v1`.
> 
>   - **Behavior**:
>     - Adds `apiVersion` field to `AutoscaledNodeGroupArgs` in `autoscaledNodegroup.go`, allowing specification of Karpenter API version.
>     - Default `apiVersion` to `v1` if not provided in `autoscaledNodegroup.go`, `AutoscaledNodeGroup.cs`, `autoscaledNodeGroup.go`, `autoscaledNodeGroup.ts`, and `autoscaled_node_group.py`.
>   - **Schema**:
>     - Updates `schema.yaml` to include `apiVersion` with default `v1` for `AutoscaledNodeGroup`.
>   - **SDKs**:
>     - Updates `AutoscaledNodeGroupArgs` in `AutoscaledNodeGroup.cs`, `autoscaledNodeGroup.go`, `autoscaledNodeGroup.ts`, and `autoscaled_node_group.py` to include `apiVersion`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lbrlabs%2Fpulumi-lbrlabs-eks&utm_source=github&utm_medium=referral)<sup> for 34fddad90ee001dca294b131537c526873bfbc9c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->