### PR TITLE
feat: add NginxIngressTag to EKS cluster configuration

### DIFF
--- a/provider/pkg/provider/cluster.go
+++ b/provider/pkg/provider/cluster.go
@@ -61,6 +61,7 @@ type ClusterArgs struct {
 	Tags                         *pulumi.StringMapInput   `pulumi:"tags"`
 	NginxIngressVersion          pulumi.StringInput       `pulumi:"nginxIngressVersion"`
 	NginxIngressRegistry         pulumi.StringInput       `pulumi:"nginxIngressRegistry"`
+	NginxIngressTag              pulumi.StringInput       `pulumi:"nginxIngressTag"`
 	EksIamAuthControllerVersion  pulumi.StringInput       `pulumi:"eksIamAuthControllerVersion"`
 	ExternalDNSVersion           pulumi.StringInput       `pulumi:"externalDNSVersion"`
 	CertManagerVersion           pulumi.StringInput       `pulumi:"certManagerVersion"`
@@ -649,6 +650,7 @@ func NewCluster(ctx *pulumi.Context,
 			Chart:     pulumi.String("ingress-nginx"),
 			Namespace: pulumi.String("kube-system"),
 			Version:   args.NginxIngressVersion,
+
 			FetchArgs: &helm.FetchArgs{
 				Repo: pulumi.String("https://kubernetes.github.io/ingress-nginx"),
 			},
@@ -656,6 +658,7 @@ func NewCluster(ctx *pulumi.Context,
 				"controller": pulumi.Map{
 					"image": pulumi.Map{
 						"registry": args.NginxIngressRegistry,
+						"tag": 	args.NginxIngressTag,
 					},
 					"metrics": pulumi.Map{
 						"enabled": realisedIngressConfig.EnableMetrics,

--- a/schema.yaml
+++ b/schema.yaml
@@ -150,6 +150,10 @@ resources:
         type: string
         description: The container registry to pull images from.
         default: "registry.k8s.io"
+      nginxIngressTag:
+        type: string
+        description: The tag to use for the nginx ingress controller images.
+        default: "v1.12.0"
       eksIamAuthControllerVersion:
         type: string
         description: The version of the eks-iam-auth-controller helm chart to deploy.

--- a/sdk/dotnet/Eks/Cluster.cs
+++ b/sdk/dotnet/Eks/Cluster.cs
@@ -215,6 +215,12 @@ namespace Lbrlabs.PulumiPackage.Eks
         public Input<string>? NginxIngressRegistry { get; set; }
 
         /// <summary>
+        /// The tag to use for the nginx ingress controller images.
+        /// </summary>
+        [Input("nginxIngressTag")]
+        public Input<string>? NginxIngressTag { get; set; }
+
+        /// <summary>
         /// The version of the nginx ingress controller helm chart to deploy.
         /// </summary>
         [Input("nginxIngressVersion")]
@@ -280,6 +286,7 @@ namespace Lbrlabs.PulumiPackage.Eks
             KarpenterVersion = "0.36.2";
             LbType = "nlb";
             NginxIngressRegistry = "registry.k8s.io";
+            NginxIngressTag = "v1.12.0";
         }
         public static new ClusterArgs Empty => new ClusterArgs();
     }

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -90,6 +90,9 @@ func NewCluster(ctx *pulumi.Context,
 	if args.NginxIngressRegistry == nil {
 		args.NginxIngressRegistry = pulumi.StringPtr("registry.k8s.io")
 	}
+	if args.NginxIngressTag == nil {
+		args.NginxIngressTag = pulumi.StringPtr("v1.12.0")
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Cluster
 	err := ctx.RegisterRemoteComponentResource("lbrlabs-eks:index:Cluster", name, args, &resource, opts...)
@@ -142,6 +145,8 @@ type clusterArgs struct {
 	LetsEncryptEmail *string `pulumi:"letsEncryptEmail"`
 	// The container registry to pull images from.
 	NginxIngressRegistry *string `pulumi:"nginxIngressRegistry"`
+	// The tag to use for the nginx ingress controller images.
+	NginxIngressTag *string `pulumi:"nginxIngressTag"`
 	// The version of the nginx ingress controller helm chart to deploy.
 	NginxIngressVersion *string `pulumi:"nginxIngressVersion"`
 	// The initial number of nodes in the system autoscaling group.
@@ -200,6 +205,8 @@ type ClusterArgs struct {
 	LetsEncryptEmail *string
 	// The container registry to pull images from.
 	NginxIngressRegistry pulumi.StringPtrInput
+	// The tag to use for the nginx ingress controller images.
+	NginxIngressTag pulumi.StringPtrInput
 	// The version of the nginx ingress controller helm chart to deploy.
 	NginxIngressVersion pulumi.StringPtrInput
 	// The initial number of nodes in the system autoscaling group.

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -87,6 +87,7 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["lbType"] = (args ? args.lbType : undefined) ?? "nlb";
             resourceInputs["letsEncryptEmail"] = args ? args.letsEncryptEmail : undefined;
             resourceInputs["nginxIngressRegistry"] = (args ? args.nginxIngressRegistry : undefined) ?? "registry.k8s.io";
+            resourceInputs["nginxIngressTag"] = (args ? args.nginxIngressTag : undefined) ?? "v1.12.0";
             resourceInputs["nginxIngressVersion"] = args ? args.nginxIngressVersion : undefined;
             resourceInputs["systemNodeDesiredCount"] = args ? args.systemNodeDesiredCount : undefined;
             resourceInputs["systemNodeInstanceTypes"] = args ? args.systemNodeInstanceTypes : undefined;
@@ -199,6 +200,10 @@ export interface ClusterArgs {
      * The container registry to pull images from.
      */
     nginxIngressRegistry?: pulumi.Input<string>;
+    /**
+     * The tag to use for the nginx ingress controller images.
+     */
+    nginxIngressTag?: pulumi.Input<string>;
     /**
      * The version of the nginx ingress controller helm chart to deploy.
      */

--- a/sdk/python/lbrlabs_pulumi_eks/cluster.py
+++ b/sdk/python/lbrlabs_pulumi_eks/cluster.py
@@ -44,6 +44,7 @@ class ClusterArgs:
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
                  nginx_ingress_registry: Optional[pulumi.Input[str]] = None,
+                 nginx_ingress_tag: Optional[pulumi.Input[str]] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
                  system_node_desired_count: Optional[pulumi.Input[float]] = None,
                  system_node_instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -72,6 +73,7 @@ class ClusterArgs:
         :param pulumi.Input[str] lb_type: The type of loadbalancer to provision.
         :param str lets_encrypt_email: The email address to use to issue certificates from Lets Encrypt.
         :param pulumi.Input[str] nginx_ingress_registry: The container registry to pull images from.
+        :param pulumi.Input[str] nginx_ingress_tag: The tag to use for the nginx ingress controller images.
         :param pulumi.Input[str] nginx_ingress_version: The version of the nginx ingress controller helm chart to deploy.
         :param pulumi.Input[float] system_node_desired_count: The initial number of nodes in the system autoscaling group.
         :param pulumi.Input[float] system_node_max_count: The maximum number of nodes in the system autoscaling group.
@@ -146,6 +148,10 @@ class ClusterArgs:
             nginx_ingress_registry = 'registry.k8s.io'
         if nginx_ingress_registry is not None:
             pulumi.set(__self__, "nginx_ingress_registry", nginx_ingress_registry)
+        if nginx_ingress_tag is None:
+            nginx_ingress_tag = 'v1.12.0'
+        if nginx_ingress_tag is not None:
+            pulumi.set(__self__, "nginx_ingress_tag", nginx_ingress_tag)
         if nginx_ingress_version is not None:
             pulumi.set(__self__, "nginx_ingress_version", nginx_ingress_version)
         if system_node_desired_count is not None:
@@ -427,6 +433,18 @@ class ClusterArgs:
         pulumi.set(self, "nginx_ingress_registry", value)
 
     @property
+    @pulumi.getter(name="nginxIngressTag")
+    def nginx_ingress_tag(self) -> Optional[pulumi.Input[str]]:
+        """
+        The tag to use for the nginx ingress controller images.
+        """
+        return pulumi.get(self, "nginx_ingress_tag")
+
+    @nginx_ingress_tag.setter
+    def nginx_ingress_tag(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "nginx_ingress_tag", value)
+
+    @property
     @pulumi.getter(name="nginxIngressVersion")
     def nginx_ingress_version(self) -> Optional[pulumi.Input[str]]:
         """
@@ -523,6 +541,7 @@ class Cluster(pulumi.ComponentResource):
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
                  nginx_ingress_registry: Optional[pulumi.Input[str]] = None,
+                 nginx_ingress_tag: Optional[pulumi.Input[str]] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
                  system_node_desired_count: Optional[pulumi.Input[float]] = None,
                  system_node_instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -555,6 +574,7 @@ class Cluster(pulumi.ComponentResource):
         :param pulumi.Input[str] lb_type: The type of loadbalancer to provision.
         :param str lets_encrypt_email: The email address to use to issue certificates from Lets Encrypt.
         :param pulumi.Input[str] nginx_ingress_registry: The container registry to pull images from.
+        :param pulumi.Input[str] nginx_ingress_tag: The tag to use for the nginx ingress controller images.
         :param pulumi.Input[str] nginx_ingress_version: The version of the nginx ingress controller helm chart to deploy.
         :param pulumi.Input[float] system_node_desired_count: The initial number of nodes in the system autoscaling group.
         :param pulumi.Input[float] system_node_max_count: The maximum number of nodes in the system autoscaling group.
@@ -606,6 +626,7 @@ class Cluster(pulumi.ComponentResource):
                  lb_type: Optional[pulumi.Input[str]] = None,
                  lets_encrypt_email: Optional[str] = None,
                  nginx_ingress_registry: Optional[pulumi.Input[str]] = None,
+                 nginx_ingress_tag: Optional[pulumi.Input[str]] = None,
                  nginx_ingress_version: Optional[pulumi.Input[str]] = None,
                  system_node_desired_count: Optional[pulumi.Input[float]] = None,
                  system_node_instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -672,6 +693,9 @@ class Cluster(pulumi.ComponentResource):
             if nginx_ingress_registry is None:
                 nginx_ingress_registry = 'registry.k8s.io'
             __props__.__dict__["nginx_ingress_registry"] = nginx_ingress_registry
+            if nginx_ingress_tag is None:
+                nginx_ingress_tag = 'v1.12.0'
+            __props__.__dict__["nginx_ingress_tag"] = nginx_ingress_tag
             __props__.__dict__["nginx_ingress_version"] = nginx_ingress_version
             __props__.__dict__["system_node_desired_count"] = system_node_desired_count
             __props__.__dict__["system_node_instance_types"] = system_node_instance_types


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `NginxIngressTag` parameter to EKS cluster configuration for specifying nginx ingress controller image tag.
> 
>   - **Behavior**:
>     - Adds `NginxIngressTag` to `ClusterArgs` in `cluster.go` to specify nginx ingress controller image tag.
>     - Updates `NewCluster` in `cluster.go` to use `NginxIngressTag` for Helm chart values.
>   - **Schema**:
>     - Adds `nginxIngressTag` to `schema.yaml` with default `v1.12.0`.
>   - **SDKs**:
>     - Updates `ClusterArgs` in `Cluster.cs`, `cluster.go`, `cluster.ts`, and `cluster.py` to include `NginxIngressTag`.
>     - Sets default `NginxIngressTag` to `v1.12.0` in C#, Go, Node.js, and Python SDKs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lbrlabs%2Fpulumi-lbrlabs-eks&utm_source=github&utm_medium=referral)<sup> for 1cebbe14dd6ac7f21edf8303a50639ab044e15ec. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->