### PR TITLE
feat(cluster): add karpenterQueueName for Karpenter SQS queue

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -244,6 +244,9 @@ resources:
       kubeconfig:
         "type": string
         "description": The kubeconfig for this cluster.
+      karpenterQueueName:                     # 👈 NEW
+        "type": string
+        "description": Name of the SQS queue that Karpenter uses for interruption events.
       controlPlane:
         "$ref": "/aws/v6.38.1/schema.json#/resources/aws:eks%2Fcluster:Cluster"
         "description": The Cluster control plane

--- a/sdk/dotnet/Eks/Cluster.cs
+++ b/sdk/dotnet/Eks/Cluster.cs
@@ -32,6 +32,12 @@ namespace Lbrlabs.PulumiPackage.Eks
         public Output<Pulumi.Aws.Iam.Role?> KarpenterNodeRole { get; private set; } = null!;
 
         /// <summary>
+        /// Name of the SQS queue that Karpenter uses for interruption events.
+        /// </summary>
+        [Output("karpenterQueueName")]
+        public Output<string?> KarpenterQueueName { get; private set; } = null!;
+
+        /// <summary>
         /// The kubeconfig for this cluster.
         /// </summary>
         [Output("kubeconfig")]

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -23,6 +23,8 @@ type Cluster struct {
 	ControlPlane eks.ClusterOutput `pulumi:"controlPlane"`
 	// The role created for karpenter nodes.
 	KarpenterNodeRole iam.RoleOutput `pulumi:"karpenterNodeRole"`
+	// Name of the SQS queue that Karpenter uses for interruption events.
+	KarpenterQueueName pulumi.StringPtrOutput `pulumi:"karpenterQueueName"`
 	// The kubeconfig for this cluster.
 	Kubeconfig pulumi.StringOutput `pulumi:"kubeconfig"`
 	// The OIDC provider for this cluster.
@@ -321,6 +323,11 @@ func (o ClusterOutput) ControlPlane() eks.ClusterOutput {
 // The role created for karpenter nodes.
 func (o ClusterOutput) KarpenterNodeRole() iam.RoleOutput {
 	return o.ApplyT(func(v *Cluster) iam.RoleOutput { return v.KarpenterNodeRole }).(iam.RoleOutput)
+}
+
+// Name of the SQS queue that Karpenter uses for interruption events.
+func (o ClusterOutput) KarpenterQueueName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringPtrOutput { return v.KarpenterQueueName }).(pulumi.StringPtrOutput)
 }
 
 // The kubeconfig for this cluster.

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -36,6 +36,10 @@ export class Cluster extends pulumi.ComponentResource {
      */
     public /*out*/ readonly karpenterNodeRole!: pulumi.Output<pulumiAws.iam.Role | undefined>;
     /**
+     * Name of the SQS queue that Karpenter uses for interruption events.
+     */
+    public /*out*/ readonly karpenterQueueName!: pulumi.Output<string | undefined>;
+    /**
      * The kubeconfig for this cluster.
      */
     public /*out*/ readonly kubeconfig!: pulumi.Output<string>;
@@ -98,6 +102,7 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["clusterName"] = undefined /*out*/;
             resourceInputs["controlPlane"] = undefined /*out*/;
             resourceInputs["karpenterNodeRole"] = undefined /*out*/;
+            resourceInputs["karpenterQueueName"] = undefined /*out*/;
             resourceInputs["kubeconfig"] = undefined /*out*/;
             resourceInputs["oidcProvider"] = undefined /*out*/;
             resourceInputs["systemNodes"] = undefined /*out*/;
@@ -105,6 +110,7 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["clusterName"] = undefined /*out*/;
             resourceInputs["controlPlane"] = undefined /*out*/;
             resourceInputs["karpenterNodeRole"] = undefined /*out*/;
+            resourceInputs["karpenterQueueName"] = undefined /*out*/;
             resourceInputs["kubeconfig"] = undefined /*out*/;
             resourceInputs["oidcProvider"] = undefined /*out*/;
             resourceInputs["systemNodes"] = undefined /*out*/;

--- a/sdk/python/lbrlabs_pulumi_eks/cluster.py
+++ b/sdk/python/lbrlabs_pulumi_eks/cluster.py
@@ -708,6 +708,7 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["cluster_name"] = None
             __props__.__dict__["control_plane"] = None
             __props__.__dict__["karpenter_node_role"] = None
+            __props__.__dict__["karpenter_queue_name"] = None
             __props__.__dict__["kubeconfig"] = None
             __props__.__dict__["oidc_provider"] = None
             __props__.__dict__["system_nodes"] = None
@@ -741,6 +742,14 @@ class Cluster(pulumi.ComponentResource):
         The role created for karpenter nodes.
         """
         return pulumi.get(self, "karpenter_node_role")
+
+    @property
+    @pulumi.getter(name="karpenterQueueName")
+    def karpenter_queue_name(self) -> pulumi.Output[Optional[str]]:
+        """
+        Name of the SQS queue that Karpenter uses for interruption events.
+        """
+        return pulumi.get(self, "karpenter_queue_name")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
Signed-off-by: Lee Briggs <lee@leebriggs.co.uk>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `karpenterQueueName` to `Cluster` for Karpenter SQS queue in `cluster.go`, update schema and SDKs.
> 
>   - **Behavior**:
>     - Add `karpenterQueueName` to `Cluster` in `cluster.go` to store SQS queue name for Karpenter interruption events.
>     - Update `NewCluster` function in `cluster.go` to set `karpenterQueueName`.
>   - **Schema**:
>     - Add `karpenterQueueName` to `Cluster` in `schema.yaml` with description.
>   - **SDKs**:
>     - Add `karpenterQueueName` to `Cluster` in `Cluster.cs`, `cluster.go`, `cluster.ts`, and `cluster.py`.
>   - **Misc**:
>     - Minor formatting changes in `cluster.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lbrlabs%2Fpulumi-lbrlabs-eks&utm_source=github&utm_medium=referral)<sup> for fef6c08e0cab9b1f6c5be4884c769735903e9172. You can [customize](https://app.ellipsis.dev/lbrlabs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->